### PR TITLE
Add support for MySQL URI connection strings

### DIFF
--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -125,6 +125,19 @@ MySQLConnectionParameters MySQLUtils::ParseConnectionParameters(const string &ds
 			} else {
 				result.client_flag &= ~CLIENT_COMPRESS;
 			}
+		} else if (key == "compression") {
+			set_options.insert("compress");
+			auto val = StringUtil::Lower(value);
+			if (val == "required") {
+				result.client_flag |= CLIENT_COMPRESS;
+			} else if (val == "disabled") {
+				result.client_flag &= ~CLIENT_COMPRESS;
+			} else if (val == "preferred") {
+				// nop
+			} else {
+				throw InvalidInputException("Invalid dsn - compression mode must be either disabled/required/preferred - got %s",
+											value);
+			}
 		} else if (key == "ssl_mode") {
 			set_options.insert("ssl_mode");
 			auto val = StringUtil::Lower(value);

--- a/test/sql/attach_dsn.test
+++ b/test/sql/attach_dsn.test
@@ -6,12 +6,6 @@ require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-# dsn parsing failures
-statement error
-ATTACH 'host' AS s (TYPE MYSQL_SCANNER)
-----
-expected key=value pairs separated by spaces
-
 statement error
 ATTACH 'host=' AS s (TYPE MYSQL_SCANNER)
 ----

--- a/test/sql/attach_uri.test
+++ b/test/sql/attach_uri.test
@@ -1,0 +1,61 @@
+# name: test/sql/attach_uri.test
+# description: Test attaching using a URI
+# group: [storage]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+# create a default secret that fills in the correct missing values in the URI
+statement ok
+CREATE SECRET (
+	TYPE MYSQL,
+	HOST localhost,
+	USER root,
+	PORT 0
+);
+
+# try various URIs
+foreach uri mysql://localhost mysql://localhost:0 mysql://root@localhost mysql://root@localhost:0 mysql://root:@localhost:0 mysql://root:@localhost:0?compression=preferred
+
+statement ok
+ATTACH '${uri}' AS uri_attach (TYPE MYSQL)
+
+statement ok
+DETACH uri_attach
+
+endloop
+
+# now with an unknown database
+foreach uri mysql://localhost/unknown_db mysql://localhost:0/unknown_db mysql://root@localhost/unknown_db mysql://root@localhost:0/unknown_db mysql://root:@localhost:0/unknown_db
+
+statement error
+ATTACH '${uri}' AS secret_attach (TYPE MYSQL)
+----
+unknown_db
+
+endloop
+
+# invalid URIs
+foreach uri mysql://abc@abc@localhost mysql://abc:abc:abc mysql://abc:abc/abc/abc mysql://localhost?abc mysql://localhost?abc=1?abc=2
+
+statement error
+ATTACH '${uri}' AS secret_attach (TYPE MYSQL)
+----
+Invalid URI string
+
+endloop
+
+# unrecognized attribute
+statement error
+ATTACH 'mysql://root@localhost?unrecognized_attribute=42' AS secret_attach (TYPE MYSQL)
+----
+unrecognized_attribute
+
+statement error
+ATTACH 'mysql://root@localhost?attribute_with_escape_codes_%20%3C%3E%23%25%2B%7B%7D%7C%5C%5E%7E%5B%5D%60%3B%2F%3F%3A%40%3D%26%24%XX%=42' AS secret_attach (TYPE MYSQL)
+----
+attribute_with_escape_codes_ <>#%+{}|\^~[]`;/?;@=&$%XX%

--- a/test/sql/attach_uri.test
+++ b/test/sql/attach_uri.test
@@ -18,8 +18,15 @@ CREATE SECRET (
 	PORT 0
 );
 
+# uri with mysql: prefix
+statement ok
+ATTACH 'mysql:root@localhost' AS uri_attach
+
+statement ok
+DETACH uri_attach
+
 # try various URIs
-foreach uri mysql://localhost mysql://localhost:0 mysql://root@localhost mysql://root@localhost:0 mysql://root:@localhost:0 mysql://root:@localhost:0?compression=preferred
+foreach uri localhost root@localhost mysql://localhost mysql://localhost:0 mysql://root@localhost mysql://root@localhost:0 mysql://root:@localhost:0 mysql://root:@localhost:0?compression=preferred
 
 statement ok
 ATTACH '${uri}' AS uri_attach (TYPE MYSQL)


### PR DESCRIPTION
Implements #99

This adds support for connecting using MySQL's URI connection strings as detailed [here](https://dev.mysql.com/doc/refman/8.4/en/connecting-using-uri-or-key-value-pairs.html#connecting-using-uri).

```
[scheme://][user[:[password]]@]host[:port][/schema][?attribute1=value1&attribute2=value2...
```

Examples:

```sql
ATTACH 'mysql:user@host' ;
ATTACH 'mysql:user@host/database' ;
ATTACH 'mysql:user:password@host:port/database?att1=val1&att2=val2' ;
ATTACH 'mysql://user@host/database' (TYPE mysql);
```

The system will automatically try to choose between the URI and the standard `key=value` connection options. The URI option can be forced by prefixing the connection string using `mysql://`, e.g.:

```sql
ATTACH 'mysql://user@host/database' (TYPE mysql);
```
