### PR TITLE
added get_bind_info to scan to extract table info

### DIFF
--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -179,12 +179,20 @@ static unique_ptr<FunctionData> MySQLScanDeserialize(Deserializer &deserializer,
 	throw NotImplementedException("MySQLScanDeserialize");
 }
 
+static BindInfo MySQLGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
+	auto &bind_data = bind_data_p->Cast<MySQLBindData>();
+	BindInfo info(ScanType::EXTERNAL);
+	info.table = bind_data.table;
+	return info;
+}
+
 MySQLScanFunction::MySQLScanFunction()
     : TableFunction("mysql_scan", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, MySQLScan,
                     MySQLBind, MySQLInitGlobalState, MySQLInitLocalState) {
 	to_string = MySQLScanToString;
 	serialize = MySQLScanSerialize;
 	deserialize = MySQLScanDeserialize;
+	get_bind_info = MySQLGetBindInfo;
 	projection_pushdown = true;
 }
 

--- a/test/sql/attach_constraints.test
+++ b/test/sql/attach_constraints.test
@@ -1,0 +1,19 @@
+# name: test/sql/attach_constraints.test
+# description: Test create table with constraints and use describe
+# group: [storage]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysql' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+CREATE OR REPLACE TABLE s1.constraints(s STRING NOT NULL, i INTEGER DEFAULT 12);
+
+query IIIIII
+DESCRIBE s1.constraints
+----
+s	VARCHAR	NO	NULL	NULL	NULL
+i	INTEGER	YES	NULL	12	NULL


### PR DESCRIPTION
The same issue was observed in `duckdb-postgres`, where defaults and constraints (e.g., NOT NULL) were not correctly interpreted when describing tables (see https://github.com/duckdb/duckdb-postgres/issues/283). The same behavior was present in this repository, causing `DESCRIBE` to incorrectly display `NULL` constraints and defaults due to missing `get_bind_info`. Just for the sake of completeness, this PR fixes this issue.