### PR TITLE
Fix BOOLEAN const pushdown to not include quotes 

### DIFF
--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -569,7 +569,7 @@ static string TransformBlobToMySQL(const string &val) {
 }
 
 string MySQLUtils::TransformConstant(const Value& val) {
-	if (val.type().IsNumeric()) {
+	if (val.type().IsNumeric() || val.type().id() == LogicalTypeId::BOOLEAN) {
 		return val.ToSQLString();
 	}
 	if (val.type().id() == LogicalTypeId::BLOB) {

--- a/src/storage/mysql_execute_query.cpp
+++ b/src/storage/mysql_execute_query.cpp
@@ -170,7 +170,7 @@ PhysicalOperator &MySQLCatalog::PlanDelete(ClientContext &context, PhysicalPlanG
 string ConstructUpdateStatement(LogicalUpdate &op, PhysicalOperator &child) {
 	// FIXME - all of this is pretty gnarly, we should provide a hook earlier on
 	// in the planning process to convert this into a SQL statement
-	string result = "UPDATE";
+	string result = "UPDATE ";
 	result += MySQLUtils::WriteIdentifier(op.table.schema.name);
 	result += ".";
 	result += MySQLUtils::WriteIdentifier(op.table.name);

--- a/test/sql/attach_filter_pushdown.test
+++ b/test/sql/attach_filter_pushdown.test
@@ -66,7 +66,7 @@ SELECT COUNT(*) FROM s1.datetime_tbl WHERE ts >= TIMESTAMP '2000-01-01'
 
 # boolean pushdown
 query I
-SELECT COUNT(*) FROM s1.booleans WHERE b = true
+SELECT * FROM s1.booleans WHERE b = true
 ----
 1
 

--- a/test/sql/scan_bool.test
+++ b/test/sql/scan_bool.test
@@ -18,3 +18,50 @@ SELECT * FROM booleans
 0
 1
 NULL
+
+# check boolean roundtrip
+
+statement ok
+CREATE OR REPLACE TABLE scan_bool_1 (col1 INTEGER, col2 BOOLEAN)
+
+query I
+SELECT column_type FROM (
+  DESCRIBE SELECT * FROM scan_bool_1
+)
+----
+INTEGER
+BOOLEAN
+
+statement ok
+INSERT INTO scan_bool_1 VALUES (1, TRUE), (2, FALSE), (3, 1), (4, 0)
+
+query II
+SELECT * FROM scan_bool_1
+----
+1	true
+2	false
+3	true
+4	false
+
+statement ok 
+UPDATE scan_bool_1 SET col2 = FALSE WHERE col1 = 1
+
+statement ok 
+UPDATE scan_bool_1 SET col2 = TRUE WHERE col1 = 2
+
+statement ok 
+UPDATE scan_bool_1 SET col2 = 0 WHERE col1 = 3
+
+statement ok 
+UPDATE scan_bool_1 SET col2 = 1 WHERE col1 = 4
+
+query II
+SELECT * FROM scan_bool_1
+----
+1	false
+2	true
+3	false
+4	true
+
+statement ok
+DROP TABLE IF EXISTS scan_bool_1


### PR DESCRIPTION
When a filter with a `BOOLEAN` constant is pushed down to attached MySQL DB, current implementation treats it as a VARCHAR` and incidentally transforms the filter:

```sql
a = TRUE
```

into:

```sql
a = 'TRUE'
```

that, when executed, is always false for `BOOLEAN` values.

This change makes the handling for `BOOLEAN` constant values in pushdowns to be the same same as numeric values, so they are passed without additional quotes.

Additionally it fixes the typo (missed space) when generating an `UPDATE` query.

Testing: pushdown test is updated to output the actual column value instead of the `COUNT` so it can catch this problem; scan test is updated to cover the boolean roundrip on insert/update.