### PR TITLE
Allow setting MySQL session time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ SELECT * FROM mysql_db.tmp;
 | mysql_tinyint1_as_boolean          | Whether or not to convert TINYINT(1) columns to BOOLEAN        | true    |
 | mysql_debug_show_queries           | DEBUG SETTING: print all queries sent to MySQL to stdout       | false   |
 | mysql_bit1_as_boolean              | Whether or not to convert BIT(1) columns to BOOLEAN            | true    |
+| mysql_session_time_zone            | Value to use as a session time zone for newly opened connections to MySQL server | ''    |
 
 ## Schema Cache
 

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -117,6 +117,9 @@ static void LoadInternal(DatabaseInstance &db) {
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), MySQLClearCacheFunction::ClearCacheOnSetting);
 	config.AddExtensionOption("mysql_bit1_as_boolean", "Whether or not to convert BIT(1) columns to BOOLEAN",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), MySQLClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption("mysql_session_time_zone", "Value to use as a session time zone for newly opened"
+	                          " connections to MySQL server", LogicalType::VARCHAR, Value(""),
+	                          MySQLClearCacheFunction::ClearCacheOnSetting);
 
 	OptimizerExtension mysql_optimizer;
 	mysql_optimizer.optimize_function = MySQLOptimizer::Optimize;

--- a/test/sql/session_timezone.test
+++ b/test/sql/session_timezone.test
@@ -1,0 +1,34 @@
+# name: test/sql/session_timezone.test
+# description: Test setting session time zone
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS msql (TYPE MYSQL_SCANNER)
+
+statement ok
+USE msql
+
+query I
+CALL mysql_query('msql', 'SELECT @@session.time_zone')
+----
+<REGEX>:^[^\-][^0][^5][^:][^0][^0].*
+
+statement ok
+SET mysql_session_time_zone = '-05:00'
+
+query I
+CALL mysql_query('msql', 'SELECT @@session.time_zone')
+----
+-05:00
+
+statement ok
+SET mysql_session_time_zone = ''
+
+query I
+CALL mysql_query('msql', 'SELECT @@session.time_zone')
+----
+<REGEX>:^[^\-][^0][^5][^:][^0][^0].*


### PR DESCRIPTION
In MySQL `TIMESTAMP` columns have the following logic:

> MySQL converts TIMESTAMP values from the current time zone to UTC for storage, and back from UTC to the current time zone for retrieval.

This change adds a new setting `mysql_session_time_zone` (`VARCHAR`, empty by default) that is used to set the `TIME_ZONE` option in all newly opened connections to MySQL server.

There is no attempt to synchronize this new setting with the DuckDB's `TimeZone` setting for the following reasons:

1. time zones handling requires ICU extension that, in theory, may no be available to the scanner extension

2. user may want to not set this setting and rely on the MySQL server time zone setting instead (default behaviour), thus using DuckDB's time zone value for MySQL session time zone may be undesired

Testing: new test is added that checks that new setting is effective in newly opened connections.