### PR TITLE
Fix DATE const handling in UPDATE queries

### DIFF
--- a/src/include/mysql_filter_pushdown.hpp
+++ b/src/include/mysql_filter_pushdown.hpp
@@ -23,7 +23,6 @@ private:
 	static string TransformFilter(string &column_name, TableFilter &filter);
 	static string TransformComparison(ExpressionType type);
 	static string CreateExpression(string &column_name, vector<unique_ptr<TableFilter>> &filters, string op);
-	static string TransformConstant(const Value &val);
 };
 
 } // namespace duckdb

--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -64,6 +64,7 @@ public:
 	static string WriteLiteral(const string &identifier);
 	static string EscapeQuotes(const string &text, char quote);
 	static string WriteQuoted(const string &text, char quote);
+	static string TransformConstant(const Value& val);
 };
 
 } // namespace duckdb

--- a/src/mysql_filter_pushdown.cpp
+++ b/src/mysql_filter_pushdown.cpp
@@ -39,32 +39,6 @@ string MySQLFilterPushdown::TransformComparison(ExpressionType type) {
 	}
 }
 
-static string TransformBlobToMySQL(const string &val) {
-	char const HEX_DIGITS[] = "0123456789ABCDEF";
-
-	string result = "x'";
-	for (idx_t i = 0; i < val.size(); i++) {
-		uint8_t byte_val = static_cast<uint8_t>(val[i]);
-		result += HEX_DIGITS[(byte_val >> 4) & 0xf];
-		result += HEX_DIGITS[byte_val & 0xf];
-	}
-	result += "'";
-	return result;
-}
-
-string MySQLFilterPushdown::TransformConstant(const Value &val) {
-	if (val.type().IsNumeric()) {
-		return val.ToSQLString();
-	}
-	if (val.type().id() == LogicalTypeId::BLOB) {
-		return TransformBlobToMySQL(StringValue::Get(val));
-	}
-	if (val.type().id() == LogicalTypeId::TIMESTAMP_TZ) {
-		return val.DefaultCastAs(LogicalType::TIMESTAMP).DefaultCastAs(LogicalType::VARCHAR).ToSQLString();
-	}
-	return val.DefaultCastAs(LogicalType::VARCHAR).ToSQLString();
-}
-
 string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &filter) {
 	switch (filter.filter_type) {
 	case TableFilterType::IS_NULL:
@@ -81,7 +55,7 @@ string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &fi
 	}
 	case TableFilterType::CONSTANT_COMPARISON: {
 		auto &constant_filter = filter.Cast<ConstantFilter>();
-		auto constant_string = TransformConstant(constant_filter.constant);
+		auto constant_string = MySQLUtils::TransformConstant(constant_filter.constant);
 		auto operator_string = TransformComparison(constant_filter.comparison_type);
 		return StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
 	}
@@ -99,7 +73,7 @@ string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &fi
 			if (!in_list.empty()) {
 				in_list += ", ";
 			}
-			in_list += TransformConstant(val);
+			in_list += MySQLUtils::TransformConstant(val);
 		}
 		return column_name + " IN (" + in_list + ")";
 	}

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -554,4 +554,30 @@ string MySQLUtils::WriteLiteral(const string &identifier) {
 	return MySQLUtils::WriteQuoted(identifier, '\'');
 }
 
+static string TransformBlobToMySQL(const string &val) {
+	char const HEX_DIGITS[] = "0123456789ABCDEF";
+
+	string result = "x'";
+	for (idx_t i = 0; i < val.size(); i++) {
+		uint8_t byte_val = static_cast<uint8_t>(val[i]);
+		result += HEX_DIGITS[(byte_val >> 4) & 0xf];
+		result += HEX_DIGITS[byte_val & 0xf];
+	}
+	result += "'";
+	return result;
+}
+
+string MySQLUtils::TransformConstant(const Value& val) {
+	if (val.type().IsNumeric()) {
+		return val.ToSQLString();
+	}
+	if (val.type().id() == LogicalTypeId::BLOB) {
+		return TransformBlobToMySQL(StringValue::Get(val));
+	}
+	if (val.type().id() == LogicalTypeId::TIMESTAMP_TZ) {
+		return val.DefaultCastAs(LogicalType::TIMESTAMP).DefaultCastAs(LogicalType::VARCHAR).ToSQLString();
+	}
+	return val.DefaultCastAs(LogicalType::VARCHAR).ToSQLString();
+}
+
 } // namespace duckdb

--- a/test/sql/scan_datetime.test
+++ b/test/sql/scan_datetime.test
@@ -29,3 +29,22 @@ query IIIII
 SELECT typeof(COLUMNS(*)) FROM datetime_tbl LIMIT 1
 ----
 DATE	TIMESTAMP	TIMESTAMP WITH TIME ZONE	VARCHAR	INTEGER
+
+statement ok
+CREATE OR REPLACE TABLE scan_datetime_1(col1 INTEGER, col2 DATE);
+
+statement ok
+INSERT INTO scan_datetime_1 VALUES (1, '2020-12-30'::DATE)
+
+query II
+SELECT * FROM scan_datetime_1 ORDER BY col1
+----
+1	2020-12-30
+
+statement ok
+UPDATE scan_datetime_1 SET col2 = '2020-12-31' WHERE col1 = 1
+
+query II
+SELECT * FROM scan_datetime_1 ORDER BY col1
+----
+1	2020-12-31


### PR DESCRIPTION
When `UPDATE` queries are generated for a few types (including `DATE`) the incoming constant (in `SET` clause) is converted to `VARCHAR` using `Value#ToSQLString()` function. This call adds Postgres'-like cast suffix to the literal (like `::DATE`) and this syntax is not supported by MySQL/MariaDB.

This PR changes the constant passing in `UPDATE` using the same logic that is used for filter pushdowns.

Testing: existing test is updated to cover `UPDATE`s with `DATE` literals.

Fixes: #143