### PR TITLE
Add format-check CI job

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+---
+BasedOnStyle: LLVM
+SortIncludes: false
+TabWidth: 4
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: false
+---
+UseTab: ForIndentation
+DerivePointerAlignment: false
+PointerAlignment: Right
+AlignConsecutiveMacros: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlignAfterOpenBracket: Align
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+IncludeBlocks: Regroup
+Language: Cpp
+AccessModifierOffset: -4
+---
+Language: Java
+SpaceAfterCStyleCast: true
+---

--- a/.github/workflows/MysqlTests.yml
+++ b/.github/workflows/MysqlTests.yml
@@ -8,9 +8,50 @@ defaults:
     shell: bash
 
 jobs:
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-22.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      GEN: ninja
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Install
+        shell: bash
+        run: |
+          sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
+          sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            ninja-build \
+            clang-format-11
+          sudo pip3 install \
+            cmake-format \
+            'black==24.*' \
+            cxxheaderparser \
+            pcpp \
+            clang_format==11.0.1
+
+      - name: List Installed Packages
+        shell: bash
+        run: pip3 freeze
+
+      - name: Format Check
+        shell: bash
+        run: |
+          clang-format --version
+          clang-format --dump-config
+          black --version
+          make format-check
+
   macos:
     name: MacOS (${{ matrix.osx_build_arch }})
     runs-on: macos-latest
+    needs: format-check
     strategy:
       matrix:
         # Add commits/tags to build against other DuckDB versions
@@ -23,14 +64,14 @@ jobs:
             duckdb_arch: 'osx_amd64'
 
     env:
-      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-      OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
       GEN: ninja
+      OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       ORACLE_MYSQL_SERVER: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -89,9 +130,10 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    needs: format-check
     env:
-      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       GEN: ninja
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       MYSQL_PWD: root
       MYSQL_TEST_DATABASE_AVAILABLE: 1
@@ -110,7 +152,7 @@ jobs:
           zip
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: 'true'

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -93,16 +93,18 @@ void CastBoolFromMySQL(ClientContext &context, Vector &input, Vector &result, id
 		auto str_data = input_data[r].GetData();
 		auto str_size = input_data[r].GetSize();
 		if (str_size == 0) {
-			throw BinderException(
-			    "Failed to cast MySQL boolean - expected 1 byte element but got element of size %d\n* SET "
-			    "mysql_tinyint1_as_boolean=false to disable loading TINYINT(1) columns as booleans\n* SET "
-			    "mysql_bit1_as_boolean=false to disable loading BIT(1) columns as booleans",
-			    str_size);
+			throw BinderException("Failed to cast MySQL boolean - expected 1 byte "
+			                      "element but got element of size %d\n* SET "
+			                      "mysql_tinyint1_as_boolean=false to disable "
+			                      "loading TINYINT(1) columns as booleans\n* SET "
+			                      "mysql_bit1_as_boolean=false to disable loading "
+			                      "BIT(1) columns as booleans",
+			                      str_size);
 		}
 		// booleans are EITHER binary "1" or "0" (BIT(1))
 		// OR a number
-		// in both cases we can figure out what value it is from the first character:
-		// \0 -> zero byte, false
+		// in both cases we can figure out what value it is from the first
+		// character: \0 -> zero byte, false
 		// - -> negative number, false
 		// 0 -> zero number, false
 		if (*str_data == '\0' || *str_data == '0' || *str_data == '-') {

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -103,11 +103,13 @@ std::tuple<MySQLConnectionParameters, unordered_set<string>> MySQLUtils::ParseCo
 		key = StringUtil::Lower(key);
 
 		if (set_options.find(key) != set_options.end()) {
-			throw InvalidInputException(
-			    "Duplicate '%s' parameter in connection string. Each parameter should only be specified once.", key);
+			throw InvalidInputException("Duplicate '%s' parameter in connection string. Each parameter "
+			                            "should only be specified once.",
+			                            key);
 		}
 
-		// Handle duplicate options (except for aliased options like passwd/password which map to the same option)
+		// Handle duplicate options (except for aliased options like passwd/password
+		// which map to the same option)
 		if (key == "host") {
 			set_options.insert("host");
 			result.host = value;
@@ -143,8 +145,9 @@ std::tuple<MySQLConnectionParameters, unordered_set<string>> MySQLUtils::ParseCo
 			} else if (val == "preferred") {
 				// nop
 			} else {
-				throw InvalidInputException(
-				    "Invalid dsn - compression mode must be either disabled/required/preferred - got %s", value);
+				throw InvalidInputException("Invalid dsn - compression mode must be either "
+				                            "disabled/required/preferred - got %s",
+				                            value);
 			}
 		} else if (key == "ssl_mode") {
 			set_options.insert("ssl_mode");
@@ -160,7 +163,8 @@ std::tuple<MySQLConnectionParameters, unordered_set<string>> MySQLUtils::ParseCo
 			} else if (val == "preferred") {
 				result.ssl_mode = SSL_MODE_PREFERRED;
 			} else {
-				throw InvalidInputException("Invalid dsn - ssl mode must be either disabled, required, verify_ca, "
+				throw InvalidInputException("Invalid dsn - ssl mode must be either "
+				                            "disabled, required, verify_ca, "
 				                            "verify_identity or preferred - got %s",
 				                            value);
 			}
@@ -276,14 +280,15 @@ MYSQL *MySQLUtils::Connect(const string &dsn) {
 			    mysql_real_connect(mysql, "127.0.0.1", user, passwd, db, config.port, unix_socket, config.client_flag);
 
 			if (!result) {
-				throw IOException(
-				    "Failed to connect to MySQL database with parameters \"%s\": %s. First attempted host: %s. "
-				    "Retry with 127.0.0.1 also failed.",
-				    dsn, mysql_error(mysql), attempted_host.c_str());
+				throw IOException("Failed to connect to MySQL database with parameters "
+				                  "\"%s\": %s. First attempted host: %s. "
+				                  "Retry with 127.0.0.1 also failed.",
+				                  dsn, mysql_error(mysql), attempted_host.c_str());
 			}
 		} else {
-			throw IOException("Failed to connect to MySQL database with parameters \"%s\": %s. Attempted host: %s", dsn,
-			                  original_error.c_str(), attempted_host.c_str());
+			throw IOException("Failed to connect to MySQL database with parameters "
+			                  "\"%s\": %s. Attempted host: %s",
+			                  dsn, original_error.c_str(), attempted_host.c_str());
 		}
 	}
 	if (mysql_set_character_set(mysql, "utf8mb4") != 0) {
@@ -354,8 +359,8 @@ LogicalType MySQLUtils::TypeToLogicalType(ClientContext &context, const MySQLTyp
 	} else if (type_info.type_name == "date") {
 		return LogicalType::DATE;
 	} else if (type_info.type_name == "time") {
-		// we convert time to VARCHAR by default because TIME in MySQL is more like an
-		// interval and can store ranges between -838:00:00 to 838:00:00
+		// we convert time to VARCHAR by default because TIME in MySQL is more like
+		// an interval and can store ranges between -838:00:00 to 838:00:00
 		Value time_as_time;
 		if (context.TryGetCurrentSetting("mysql_time_as_time", time_as_time)) {
 			if (BooleanValue::Get(time_as_time)) {

--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -206,7 +206,8 @@ vector<string> GetAttributeNames(const vector<URIToken> &tokens, idx_t token_cou
 		error = ParserException("Invalid URI string - expected host:port or host/schema");
 	}
 	if (current_pos + 1 != token_count) {
-		error = ParserException("Invalid URI string - expected ? after [user[:[password]]@]host[:port][/schema]");
+		error = ParserException("Invalid URI string - expected ? after "
+		                        "[user[:[password]]@]host[:port][/schema]");
 	}
 	return result;
 }
@@ -254,7 +255,8 @@ void ParseAttributes(const vector<URIToken> &tokens, idx_t attribute_start, vect
 				}
 				supported_options += entry.first;
 			}
-			throw ParserException("Invalid URI string - unsupported attribute \"%s\"\nSupported options: %s",
+			throw ParserException("Invalid URI string - unsupported attribute "
+			                      "\"%s\"\nSupported options: %s",
 			                      tokens[i].value, supported_options);
 		}
 		result.emplace_back(entry->second, tokens[i + 1].value);
@@ -374,7 +376,8 @@ string MySQLCatalog::GetConnectionString(ClientContext &context, const string &a
 		// secret found - read data
 		const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
 
-		// Parse the original connection string to find which parameters are already set
+		// Parse the original connection string to find which parameters are already
+		// set
 		MySQLConnectionParameters unused;
 		unordered_set<string> existing_params;
 		std::tie(unused, existing_params) = MySQLUtils::ParseConnectionParameters(connection_string);

--- a/src/storage/mysql_execute_query.cpp
+++ b/src/storage/mysql_execute_query.cpp
@@ -103,7 +103,8 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
 			case ExpressionType::VALUE_CONSTANT:
 				break;
 			default:
-				throw NotImplementedException("Unsupported expression type in projection - only simple deletes/updates "
+				throw NotImplementedException("Unsupported expression type in projection - only simple "
+				                              "deletes/updates "
 				                              "are supported in the MySQL connector");
 			}
 		}

--- a/src/storage/mysql_result.cpp
+++ b/src/storage/mysql_result.cpp
@@ -55,7 +55,8 @@ bool MySQLResult::TryCancelQuery() {
 		// swap connections
 		std::swap(con.GetConnection()->connection, connection->connection);
 
-		// we cancelled the query and replaced the connection with a new one - we're done
+		// we cancelled the query and replaced the connection with a new one - we're
+		// done
 		return true;
 	} catch (...) {
 		return false;


### PR DESCRIPTION
This PR adds a `format-check` job that runs before other jobs.

It also adds the `.clang-format` config file from the mainline repo so the same formatting rules are used.