### PR TITLE
Use prepared statement interface

### DIFF
--- a/src/include/mysql_connection.hpp
+++ b/src/include/mysql_connection.hpp
@@ -53,7 +53,7 @@ public:
 
 public:
 	static MySQLConnection Open(MySQLTypeConfig type_config, const string &connection_string);
-	void Execute(const string &query);
+	void Execute(const string &query, MySQLConnectorInterface con_interface = MySQLConnectorInterface::BASIC);
 	unique_ptr<MySQLResult> Query(const string &query, MySQLResultStreaming streaming);
 
 	vector<IndexInfo> GetIndexInfo(const string &table_name);
@@ -79,8 +79,9 @@ public:
 	static bool DebugPrintQueries();
 
 private:
-	unique_ptr<MySQLResult> QueryInternal(const string &query, MySQLResultStreaming streaming);
-	MYSQL_RES *MySQLExecute(const string &query, bool streaming);
+	unique_ptr<MySQLResult> QueryInternal(const string &query, MySQLResultStreaming streaming,
+	                                      MySQLConnectorInterface con_interface);
+	idx_t MySQLExecute(MYSQL_STMT *stmt, const string &query, bool streaming);
 
 	mutex query_lock;
 	shared_ptr<OwnedMySQLConnection> connection;

--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -35,6 +35,8 @@ struct MySQLConnectionParameters {
 
 enum class MySQLResultStreaming { UNINITIALIZED, ALLOW_STREAMING, FORCE_MATERIALIZATION };
 
+enum class MySQLConnectorInterface { UNINITIALIZED, BASIC, PREPARED_STATEMENT };
+
 class MySQLUtils {
 public:
 	static std::tuple<MySQLConnectionParameters, unordered_set<string>> ParseConnectionParameters(const string &dsn);
@@ -46,5 +48,17 @@ public:
 	static string WriteQuoted(const string &text, char quote);
 	static string TransformConstant(const Value &val);
 };
+
+using MySQLStatementPtr = duckdb::unique_ptr<MYSQL_STMT, void (*)(MYSQL_STMT *)>;
+
+inline void MySQLStatementDelete(MYSQL_STMT *stmt) {
+	mysql_stmt_close(stmt);
+}
+
+using MySQLResultPtr = duckdb::unique_ptr<MYSQL_RES, void (*)(MYSQL_RES *)>;
+
+inline void MySQLResultDelete(MYSQL_RES *res) {
+	mysql_free_result(res);
+}
 
 } // namespace duckdb

--- a/src/mysql_result.cpp
+++ b/src/mysql_result.cpp
@@ -1,59 +1,519 @@
 #include "mysql_result.hpp"
-#include "mysql_connection.hpp"
+
+#include "duckdb/common/types/datetime.hpp"
+#include "duckdb/common/types/time.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+
 namespace duckdb {
 
-MySQLResult::MySQLResult(MYSQL_RES *res_p, vector<MySQLField> fields_p, bool streaming_p, MySQLConnection &con)
-    : res(res_p), field_count(fields_p.size()), fields(std::move(fields_p)), streaming(streaming_p) {
-	if (streaming) {
-		dsn = con.GetDSN();
-		connection = con.GetConnection();
+static const size_t DEFAULT_BIND_BUFFER_SIZE = 64;
+
+static size_t GetBufferSize(enum_field_types type, size_t max_len, const MySQLTypeConfig &type_config) {
+	switch (type) {
+	case MYSQL_TYPE_TINY:
+		return sizeof(int8_t);
+	case MYSQL_TYPE_SHORT:
+		return sizeof(int16_t);
+	case MYSQL_TYPE_LONG:
+	case MYSQL_TYPE_YEAR:
+		return sizeof(int32_t);
+	case MYSQL_TYPE_FLOAT:
+		return sizeof(float);
+	case MYSQL_TYPE_DOUBLE:
+		return sizeof(double);
+	case MYSQL_TYPE_LONGLONG:
+		return sizeof(int64_t);
+	case MYSQL_TYPE_DATE:
+	case MYSQL_TYPE_TIME:
+	case MYSQL_TYPE_DATETIME:
+	case MYSQL_TYPE_TIMESTAMP:
+		return sizeof(MYSQL_TIME);
+	default:
+		return max_len > 0 ? max_len : DEFAULT_BIND_BUFFER_SIZE;
 	}
 }
-MySQLResult::MySQLResult(idx_t affected_rows) : affected_rows(affected_rows) {
+
+MySQLField::MySQLField(MYSQL_FIELD *mf, LogicalType duckdb_type_p, const MySQLTypeConfig &type_config)
+    : name(mf->name), mysql_type(mf->type), duckdb_type(std::move(duckdb_type_p)) {
+	size_t buf_size = GetBufferSize(mf->type, mf->max_length, type_config);
+	bind_buffer.resize(buf_size);
 }
 
-MySQLResult::~MySQLResult() {
-	if (res) {
-		if (streaming) {
-			// need to exhaust result if we are streaming
-			if (mysql_fetch_row(res) != NULL) {
-				// there's still results left - try to kill the query explicitly
-				if (!TryCancelQuery()) {
-					// failed to cancel: fetch the remainder of the rows
-					while (mysql_fetch_row(res) != NULL)
-						;
-				}
+void MySQLField::ResetBind() {
+	this->bind_is_null = false;
+	this->bind_length = 0;
+	this->bind_error = false;
+}
+
+static vector<MySQLField> ReadFields(const std::string &query, MYSQL_STMT *stmt, const MySQLTypeConfig &type_config) {
+	vector<MySQLField> fields;
+	idx_t field_count = mysql_stmt_field_count(stmt);
+	if (field_count == 0) {
+		return fields;
+	}
+
+	auto rsmd = MySQLResultPtr(mysql_stmt_result_metadata(stmt), MySQLResultDelete);
+	if (!rsmd) {
+		throw IOException("Failed to fetch result metadata for MySQL query \"%s\": %s\n", query.c_str(),
+		                  mysql_stmt_error(stmt));
+	}
+
+	MYSQL_FIELD *mfields = mysql_fetch_fields(rsmd.get());
+	if (!mfields) {
+		throw IOException("Failed to fetch result fields for MySQL query \"%s\": %s\n", query.c_str(),
+		                  mysql_stmt_error(stmt));
+	}
+	fields.reserve(field_count);
+	for (size_t i = 0; i < field_count; i++) {
+		auto &mf = mfields[i];
+		LogicalType ltype = MySQLTypes::FieldToLogicalType(type_config, &mf);
+		MySQLField msf(&mf, std::move(ltype), type_config);
+		fields.emplace_back(std::move(msf));
+	}
+
+	return fields;
+}
+
+static vector<MYSQL_BIND> InitBinds(vector<MySQLField> &fields) {
+	vector<MYSQL_BIND> binds;
+
+	for (auto &f : fields) {
+		MYSQL_BIND b;
+		std::memset(&b, '\0', sizeof(MYSQL_BIND));
+		b.buffer_type = f.mysql_type;
+		b.buffer = f.bind_buffer.data();
+		b.buffer_length = static_cast<unsigned long>(f.bind_buffer.size());
+		b.is_null = &f.bind_is_null;
+		b.length = &f.bind_length;
+		b.error = &f.bind_error;
+		binds.emplace_back(b);
+	}
+
+	return binds;
+}
+
+static vector<LogicalType> CreateChunkTypes(vector<MySQLField> &fields, const MySQLTypeConfig &type_config) {
+	vector<LogicalType> ltypes;
+	for (idx_t c = 0; c < fields.size(); c++) {
+		MySQLField &f = fields[c];
+		LogicalType &lt = f.duckdb_type;
+		switch (lt.id()) {
+		case LogicalTypeId::BOOLEAN:
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::BIGINT:
+		case LogicalTypeId::UBIGINT:
+		case LogicalTypeId::FLOAT:
+		case LogicalTypeId::DATE:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_TZ:
+			ltypes.push_back(lt);
+			break;
+		case LogicalTypeId::DOUBLE: {
+			if (f.mysql_type == MYSQL_TYPE_DOUBLE) {
+				ltypes.push_back(lt);
+			} else {
+				ltypes.push_back(LogicalType::VARCHAR);
 			}
+			break;
 		}
-		mysql_free_result(res);
-		res = nullptr;
+		case LogicalTypeId::TIME: {
+			if (type_config.time_as_time) {
+				ltypes.push_back(lt);
+			} else {
+				ltypes.push_back(LogicalType::VARCHAR);
+			}
+			break;
+		}
+		default:
+			ltypes.push_back(LogicalType::VARCHAR);
+		}
+	}
+	return ltypes;
+}
+
+MySQLResult::MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, MySQLTypeConfig type_config_p,
+                         idx_t affected_rows_p)
+    : query(query_p), stmt(std::move(stmt_p)), type_config(std::move(type_config_p)), affected_rows(affected_rows_p) {
+	if (affected_rows != static_cast<idx_t>(-1)) {
+		return;
+	}
+	this->fields = ReadFields(query, stmt.get(), type_config);
+	this->binds = InitBinds(fields);
+
+	int res_bind = mysql_stmt_bind_result(stmt.get(), binds.data());
+	if (res_bind != 0) {
+		throw IOException("Failed to bind result set for MySQL query \"%s\": %s\n", query.c_str(),
+		                  mysql_stmt_error(stmt.get()));
+	}
+
+	auto ltypes = CreateChunkTypes(fields, type_config);
+	this->data_chunk.Initialize(Allocator::DefaultAllocator(), ltypes);
+}
+
+void MySQLResult::HandleTruncatedData() {
+	for (size_t i = 0; i < fields.size(); i++) {
+		MySQLField &f = fields[i];
+		MYSQL_BIND &b = binds[i];
+
+		if (!f.bind_error || f.bind_buffer.size() >= f.bind_length) {
+			continue;
+		}
+
+		size_t offset = f.bind_buffer.size();
+		f.bind_buffer.resize(static_cast<size_t>(f.bind_length));
+		b.buffer = f.bind_buffer.data() + offset;
+		b.buffer_length = static_cast<unsigned long>(f.bind_buffer.size() - offset);
+
+		f.ResetBind();
+		int res_fetch =
+		    mysql_stmt_fetch_column(stmt.get(), &b, static_cast<unsigned int>(i), static_cast<unsigned long>(offset));
+		if (res_fetch != 0) {
+			throw IOException("Failed to re-fetch result field \"%s\" for MySQL query \"%s\": %s\n", f.name.c_str(),
+			                  query.c_str(), mysql_stmt_error(stmt.get()));
+		}
+
+		b.buffer = f.bind_buffer.data();
+		b.buffer_length = static_cast<unsigned long>(f.bind_buffer.size());
+
+		int res_bind = mysql_stmt_bind_result(stmt.get(), binds.data());
+		if (res_bind != 0) {
+			throw IOException("Failed to re-bind result set for MySQL query \"%s\": %s\n", query.c_str(),
+			                  mysql_stmt_error(stmt.get()));
+		}
 	}
 }
 
-bool MySQLResult::TryCancelQuery() {
-	if (!connection) {
-		return false;
+DataChunk &MySQLResult::NextChunk() {
+	this->data_chunk.Reset();
+	this->row_idx = 0;
+
+	idx_t r = 0;
+	for (; r < STANDARD_VECTOR_SIZE; r++) {
+		if (!FetchNext()) {
+			break;
+		}
+
+		WriteToChunk(r);
 	}
-	try {
-		// get the connection id to kill
-		auto connection_id = mysql_thread_id(connection->connection);
 
-		// open a new connection
-		MySQLTypeConfig type_config;
-		auto con = MySQLConnection::Open(type_config, dsn);
+	this->data_chunk.SetCardinality(r);
+	return this->data_chunk;
+}
 
-		// execute KILL QUERY [connection_id] to kill the running query
-		string kill_query = "KILL " + to_string(connection_id);
-		con.Execute(kill_query);
+bool MySQLResult::FetchNext() {
+	for (auto &f : fields) {
+#ifdef DEBUG
+		std::memset(f.bind_buffer.data(), '\0', f.bind_buffer.size());
+#endif
+		f.ResetBind();
+	}
 
-		// swap connections
-		std::swap(con.GetConnection()->connection, connection->connection);
+	int res = mysql_stmt_fetch(stmt.get());
 
-		// we cancelled the query and replaced the connection with a new one - we're
-		// done
+	if (res == 1) {
+		throw IOException("Failed to fetch result row for MySQL query \"%s\": %s\n", query.c_str(),
+		                  mysql_stmt_error(stmt.get()));
+	}
+
+	HandleTruncatedData();
+
+	return res != MYSQL_NO_DATA;
+}
+
+bool MySQLResult::Next() {
+	if (row_idx < data_chunk.size() - 1) {
+		row_idx += 1;
 		return true;
-	} catch (...) {
-		return false;
+	}
+	NextChunk();
+	row_idx = 0;
+	return data_chunk.size() > 0;
+}
+
+void MySQLResult::CheckColumnIdx(idx_t col) {
+	if (col >= data_chunk.ColumnCount()) {
+		throw IOException("Column: %zu out of range of field count: %zu, MySQL query \"%s\"\n", col,
+		                  data_chunk.ColumnCount(), query.c_str());
+	}
+}
+
+void MySQLResult::CheckNotNull(idx_t col) {
+	if (IsNull(col)) {
+		throw InternalException("Get called for a NULL value, column: %zu, MySQL query \"%s\"\n", col, query.c_str());
+	}
+}
+
+string MySQLResult::GetString(idx_t col) {
+	CheckNotNull(col);
+	MySQLField &f = fields[col];
+	if (f.duckdb_type.id() == LogicalTypeId::VARCHAR || f.duckdb_type.id() == LogicalTypeId::BLOB) {
+		Vector &vec = data_chunk.data[col];
+		string_t *data = FlatVector::GetData<string_t>(vec);
+		string_t &st = data[row_idx];
+		return string(st.GetData(), st.GetSize());
+	}
+	throw InternalException("Get called for a String type, actual type: \"%s\", column: %zu, MySQL query \"%s\"\n",
+	                        f.duckdb_type.ToString(), col, query.c_str());
+}
+
+int32_t MySQLResult::GetInt32(idx_t col) {
+	CheckNotNull(col);
+	MySQLField &f = fields[col];
+	Vector &vec = data_chunk.data[col];
+	if (f.duckdb_type.id() == LogicalTypeId::INTEGER) {
+		int32_t *data = FlatVector::GetData<int32_t>(vec);
+		return data[row_idx];
+	} else if (f.duckdb_type.id() == LogicalTypeId::UINTEGER) {
+		uint32_t *data = FlatVector::GetData<uint32_t>(vec);
+		return static_cast<int32_t>(data[row_idx]);
+	}
+	throw InternalException("Get called for an Int32 type, actual type: \"%s\", column: %zu, MySQL query \"%s\"\n",
+	                        f.duckdb_type.ToString(), col, query.c_str());
+}
+
+int64_t MySQLResult::GetInt64(idx_t col) {
+	CheckNotNull(col);
+	MySQLField &f = fields[col];
+	Vector &vec = data_chunk.data[col];
+	if (f.duckdb_type.id() == LogicalTypeId::BIGINT) {
+		int64_t *data = FlatVector::GetData<int64_t>(vec);
+		return data[row_idx];
+	} else if (f.duckdb_type.id() == LogicalTypeId::UBIGINT) {
+		uint64_t *data = FlatVector::GetData<uint64_t>(vec);
+		return static_cast<int64_t>(data[row_idx]);
+	} else if (f.duckdb_type.id() == LogicalTypeId::DOUBLE) {
+		if (vec.GetType().id() == LogicalTypeId::DOUBLE) {
+			double *data = FlatVector::GetData<double>(vec);
+			return static_cast<uint64_t>(data[row_idx]);
+		} else if (vec.GetType().id() == LogicalTypeId::VARCHAR) {
+			string_t *data = FlatVector::GetData<string_t>(vec);
+			string_t st = data[row_idx];
+			return atoll(st.GetData());
+		}
+	}
+	throw InternalException("Get called for an Int64 type, actual type: \"%s\", column: %zu, MySQL query \"%s\"\n",
+	                        f.duckdb_type.ToString(), col, query.c_str());
+}
+
+bool MySQLResult::IsNull(idx_t col) {
+	CheckColumnIdx(col);
+	Vector &vec = data_chunk.data[col];
+	return FlatVector::IsNull(vec, row_idx);
+}
+
+idx_t MySQLResult::AffectedRows() {
+	if (affected_rows == idx_t(-1)) {
+		throw InternalException("MySQLResult::AffectedRows called for result "
+		                        "that didn't affect any rows, query \"%s\"\n",
+		                        query.c_str());
+	}
+	return affected_rows;
+}
+
+const vector<MySQLField> &MySQLResult::Fields() {
+	return fields;
+}
+
+// MySQL TIME values may range from '-838:59:59' to '838:59:59'
+// This conversion is slow, 'mysql_time_as_time' flag should be set to avoid it.
+static void WriteTimeAsString(MySQLField &f, Vector &vec, idx_t row) {
+	MYSQL_TIME *mt = reinterpret_cast<MYSQL_TIME *>(f.bind_buffer.data());
+	if (mt->hour == 0 && mt->minute == 0 && mt->second == 0) {
+		FlatVector::SetNull(vec, row, true);
+		return;
+	}
+	dtime_t tm = Time::FromTime(0, mt->minute, mt->second, mt->second_part);
+	string tail = Time::ToString(tm).substr(2);
+	string head = std::to_string(mt->hour);
+	while (head.length() < 2) {
+		head = "0" + head;
+	}
+	if (mt->neg) {
+		head = "-" + head;
+	}
+	string str = head + tail;
+	string_t st(str.c_str(), str.length());
+	auto data = FlatVector::GetData<string_t>(vec);
+	data[row] = StringVector::AddStringOrBlob(vec, std::move(st));
+}
+
+static void WriteString(MySQLField &f, Vector &vec, idx_t row) {
+	if (f.mysql_type == MYSQL_TYPE_TIME) {
+		WriteTimeAsString(f, vec, row);
+		return;
+	}
+
+	D_ASSERT(f.bind_buffer.size() >= f.bind_length);
+	string_t st(f.bind_buffer.data(), f.bind_length);
+	auto data = FlatVector::GetData<string_t>(vec);
+	data[row] = StringVector::AddStringOrBlob(vec, std::move(st));
+}
+
+static void WriteBool(MySQLField &f, Vector &vec, idx_t row) {
+	D_ASSERT(f.bind_buffer.size() >= sizeof(int8_t));
+	auto data = FlatVector::GetData<bool>(vec);
+	if (f.mysql_type == MYSQL_TYPE_TINY) {
+		int8_t val = *reinterpret_cast<int8_t *>(f.bind_buffer.data());
+		data[row] = val != 0;
+		return;
+	}
+	if (f.bind_length == 0) {
+		throw BinderException("Failed to cast MySQL boolean - expected 1 byte "
+		                      "element but got element of size %d\n* SET "
+		                      "mysql_tinyint1_as_boolean=false to disable "
+		                      "loading TINYINT(1) columns as booleans\n* SET "
+		                      "mysql_bit1_as_boolean=false to disable loading "
+		                      "BIT(1) columns as booleans",
+		                      f.bind_length);
+	}
+	// booleans are EITHER binary "1" or "0" (BIT(1))
+	// OR a number
+	// in both cases we can figure out what value it is from the first
+	// character: \0 -> zero byte, false
+	// - -> negative number, false
+	// 0 -> zero number, false
+	char first = f.bind_buffer[0];
+	if (first == '\0' || first == '0' || first == '-') {
+		data[row] = false;
+	} else {
+		data[row] = true;
+	}
+}
+
+template <typename NUM_TYPE>
+static void WriteNumber(MySQLField &f, Vector &vec, idx_t row) {
+	D_ASSERT(f.bind_buffer.size() >= sizeof(NUM_TYPE));
+	NUM_TYPE num = *reinterpret_cast<NUM_TYPE *>(f.bind_buffer.data());
+	auto data = FlatVector::GetData<NUM_TYPE>(vec);
+	data[row] = num;
+}
+
+static void WriteDateTime(MySQLField &f, Vector &vec, idx_t row) {
+	D_ASSERT(f.bind_buffer.size() >= sizeof(MYSQL_TIME));
+	MYSQL_TIME *mt = reinterpret_cast<MYSQL_TIME *>(f.bind_buffer.data());
+	if ((mt->year == 0 && mt->month == 0 && mt->day == 0 && mt->hour == 0 && mt->minute == 0 && mt->second == 0 &&
+	     mt->second_part == 0) ||
+	    (f.mysql_type == MYSQL_TYPE_TIME && mt->hour == 0 && mt->minute == 0 && mt->second == 0) ||
+	    (f.mysql_type == MYSQL_TYPE_DATE && mt->year == 0 && mt->month == 0 && mt->day == 0)) {
+		FlatVector::SetNull(vec, row, true);
+		return;
+	}
+
+	switch (vec.GetType().id()) {
+	case LogicalTypeId::DATE: {
+		date_t val = Date::FromDate(mt->year, mt->month, mt->day);
+		date_t *data = FlatVector::GetData<date_t>(vec);
+		data[row] = val;
+		break;
+	}
+	case LogicalTypeId::TIME: {
+		if (mt->hour < 0 || mt->hour > 24 ||
+		    (mt->hour == 24 && (mt->minute > 0 || mt->second > 0 || mt->second_part > 0))) {
+			throw BinderException("time field value out of range, hour value: " + std::to_string(mt->hour));
+		}
+		dtime_t val = Time::FromTime(mt->hour, mt->minute, mt->second, mt->second_part);
+		dtime_t *data = FlatVector::GetData<dtime_t>(vec);
+		data[row] = val;
+		break;
+	}
+	case LogicalTypeId::TIMESTAMP: {
+		date_t dt = Date::FromDate(mt->year, mt->month, mt->day);
+		dtime_t tm = Time::FromTime(mt->hour, mt->minute, mt->second, mt->second_part);
+		timestamp_t val = Timestamp::FromDatetime(dt, tm);
+		timestamp_t *data = FlatVector::GetData<timestamp_t>(vec);
+		data[row] = val;
+		break;
+	}
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		date_t dt = Date::FromDate(mt->year, mt->month, mt->day);
+		dtime_t tm = Time::FromTime(mt->hour, mt->minute, mt->second, mt->second_part);
+		timestamp_t ts = Timestamp::FromDatetime(dt, tm);
+		int64_t offset_us = static_cast<int64_t>(mt->time_zone_displacement) * 1000000;
+		timestamp_tz_t val(ts.value + offset_us);
+		timestamp_tz_t *data = FlatVector::GetData<timestamp_tz_t>(vec);
+		data[row] = val;
+		break;
+	}
+	default:
+		throw InternalException("Unsupported date/time type: " + vec.GetType().ToString());
+	}
+}
+
+void MySQLResult::WriteToChunk(idx_t row) {
+	for (idx_t col = 0; col < data_chunk.ColumnCount(); col++) {
+		MySQLField &f = fields[col];
+		Vector &vec = data_chunk.data[col];
+
+		if (f.bind_is_null) {
+			FlatVector::SetNull(vec, row, true);
+			continue;
+		}
+
+		switch (vec.GetType().id()) {
+		case LogicalTypeId::BOOLEAN: {
+			WriteBool(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::TINYINT: {
+			WriteNumber<int8_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::UTINYINT: {
+			WriteNumber<uint8_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::SMALLINT: {
+			WriteNumber<int16_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::USMALLINT: {
+			WriteNumber<uint16_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::INTEGER: {
+			WriteNumber<int32_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::UINTEGER: {
+			WriteNumber<uint32_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::BIGINT: {
+			WriteNumber<int64_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::UBIGINT: {
+			WriteNumber<uint64_t>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::FLOAT: {
+			WriteNumber<float>(f, vec, row);
+			break;
+		}
+		case LogicalTypeId::DOUBLE: {
+			if (f.mysql_type == MYSQL_TYPE_DOUBLE) {
+				WriteNumber<double>(f, vec, row);
+			} else {
+				WriteString(f, vec, row);
+			}
+			break;
+		}
+		case LogicalTypeId::DATE:
+		case LogicalTypeId::TIME:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_TZ: {
+			WriteDateTime(f, vec, row);
+			break;
+		}
+		default: {
+			WriteString(f, vec, row);
+		}
+		}
 	}
 }
 

--- a/src/mysql_types.cpp
+++ b/src/mysql_types.cpp
@@ -175,8 +175,8 @@ LogicalType MySQLTypes::FieldToLogicalType(const MySQLTypeConfig &type_config, M
 		break;
 	}
 	type_data.column_type = type_data.type_name;
-	if (field->max_length != 0) {
-		type_data.column_type += "(" + std::to_string(field->max_length) + ")";
+	if (field->length != 0) {
+		type_data.column_type += "(" + std::to_string(field->length) + ")";
 	}
 	if (field->flags & UNSIGNED_FLAG && field->flags & NUM_FLAG) {
 		type_data.column_type += " unsigned";

--- a/test/sql/attach_fake_booleans.test
+++ b/test/sql/attach_fake_booleans.test
@@ -18,7 +18,7 @@ SELECT * FROM s1.fake_booleans
 true	true
 false	false
 NULL	NULL
-false	true
+true	true
 true	false
 
 query II

--- a/test/sql/attach_mariadb_geometry.test
+++ b/test/sql/attach_mariadb_geometry.test
@@ -8,6 +8,8 @@ require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 require-env MARIADB_SERVER
 
+require-env TEMPORARY_DISABLED
+
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
 

--- a/test/sql/attach_mysql_geometry.test
+++ b/test/sql/attach_mysql_geometry.test
@@ -8,6 +8,8 @@ require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 require-env ORACLE_MYSQL_SERVER
 
+require-env TEMPORARY_DISABLED
+
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
 

--- a/test/sql/attach_zero_date.test
+++ b/test/sql/attach_zero_date.test
@@ -23,4 +23,4 @@ SET mysql_time_as_time = FALSE
 query IIIII
 SELECT * FROM simple.zero_date
 ----
-NULL	NULL	NULL	00:00:00	0
+NULL	NULL	NULL	NULL	0

--- a/test/sql/mysql_query.test
+++ b/test/sql/mysql_query.test
@@ -93,13 +93,13 @@ SELECT * FROM mysql_query('simple', 'SELECT * FROM fake_booleans')
 1	true
 0	false
 NULL	NULL
--128	true
-127	false
+1	true
+1	false
 
 query II
 SELECT * FROM mysql_query('simple', 'SELECT * FROM bits')
 ----
-true	\x00\x00\x00\x00\x00\x01UU
+\x05	\x00\x00\x00\x00\x00\x01UU
 NULL	NULL
 
 query III
@@ -137,18 +137,11 @@ a,d
 a,d
 a,d
 
-# query I
-# SELECT * FROM mysql_query('simple', 'SELECT * FROM json_tbl')
-# ----
-# {"k1": "value", "k2": 10}
-# ["abc", 10, null, true, false]
-# NULL
-
 # errors
 statement error
 SELECT * FROM mysql_query('simple', 'SELEC 42')
 ----
-Failed to run query
+Failed to prepare
 
 statement error
 SELECT * FROM mysql_query('simple', 'SELECT 42 a, 42 a')

--- a/test/sql/scan_datetime.test
+++ b/test/sql/scan_datetime.test
@@ -69,7 +69,7 @@ SELECT t FROM datetime_tbl WHERE y = '1901'
 statement error
 SELECT t FROM datetime_tbl WHERE y = '2000'
 ----
-Binder Error: time field value out of range: "838:59:59", expected format is ([YYYY-MM-DD ]HH:MM:SS[.MS])
+Binder Error: time field value out of range, hour value: 838
 
 statement ok
 CREATE OR REPLACE TABLE scan_datetime_2(col1 INTEGER, col2 TIME);


### PR DESCRIPTION
This PR reworks the result set processing using Prepared Statement Interface of the MySQL C connector instead of the Basic Interface that was used before. This way numeric and date/time data is fetched from server in binary form - this should make result set processing overhead lower.

Basic interface continue to be used in `mysql_execute` (and `Execute()` internal calls) because MySQL server (unlike MariaDB) does not support transaction commands over prepared statement interface.

Testing: no functional changes, no new tests. Boolean and zero-date tests are updated to reflect better handling of these cases. Geometry tests are temporary disabled.