### PR TITLE
Fix: correct colon escape and add missing URL escapes in MySQL attach URI

### DIFF
--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -87,7 +87,7 @@ struct URIToken {
 
 string UnescapePercentage(const string &input, idx_t start, idx_t end) {
 	// url escapes encoded as [ESC][RESULT]
-	auto url_escapes = "20 3C<3E>23#25%2B+7B{7D}7C|5C\\5E^7E~5B[5D]60`3B;2F/3F?3A;40@3D=26&24$";
+	auto url_escapes = "20 3C<3E>23#25%2B+7B{7D}7C|5C\\5E^7E~5B[5D]60`3B;2F/3F?3A:40@3D=26&24$21!2A*27'22\"28(29)2C,";
 
 	string result;
 	for (idx_t i = start; i < end; i++) {


### PR DESCRIPTION
This PR fixes issues with MySQL connection URIs failing when the password contained certain special characters.

### Changes
- Corrected the colon (`:`) mapping (was incorrectly set to `3A;`, now fixed to `3A:`).
- Added missing URL escape codes for:
  - `!` `*` `'` `"` `(` `)` `,`

### Impact
- Passwords containing these characters now work correctly when attaching a MySQL database using a URI.
- Example that now succeeds:

```
ATTACH 'mysql://testuser:Aa1%20~%60%21%40%23$%25%5E%26%2A%28%29_%2B-%3D%7B%7D%5B%5D%7C%5C%3B%3A%27%3C%3E%22%2C.%2F%3F@localhost:3306/test' AS uri_attach (TYPE MYSQL);
```
for Password ``Aa1 ~`!@#$%^&*()_+-={}[]|\;:'<>",./?``