### PR TITLE
Fix: correct colon escape and add missing URL escapes in MySQL attach URI

### DIFF
--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -87,7 +87,7 @@ struct URIToken {
 
 string UnescapePercentage(const string &input, idx_t start, idx_t end) {
 	// url escapes encoded as [ESC][RESULT]
-	auto url_escapes = "20 3C<3E>23#25%2B+7B{7D}7C|5C\\5E^7E~5B[5D]60`3B;2F/3F?3A;40@3D=26&24$";
+	auto url_escapes = "20 3C<3E>23#25%2B+7B{7D}7C|5C\\5E^7E~5B[5D]60`3B;2F/3F?3A:40@3D=26&24$21!2A*27'22\"28(29)2C,";
 
 	string result;
 	for (idx_t i = start; i < end; i++) {

--- a/test/sql/attach_uri.test
+++ b/test/sql/attach_uri.test
@@ -65,4 +65,9 @@ unrecognized_attribute
 statement error
 ATTACH 'mysql://root@localhost?attribute_with_escape_codes_%20%3C%3E%23%25%2B%7B%7D%7C%5C%5E%7E%5B%5D%60%3B%2F%3F%3A%40%3D%26%24%XX%=42' AS secret_attach (TYPE MYSQL)
 ----
-attribute_with_escape_codes_ <>#%+{}|\^~[]`;/?;@=&$%XX%
+attribute_with_escape_codes_ <>#%+{}|\^~[]`;/?:@=&$%XX%
+
+statement error
+ATTACH 'mysql://testuser:Aa1%20~%60%21%40%23$%25%5E%26%2A%28%29_%2B-%3D%7B%7D%5B%5D%7C%5C%3B%3A%27%3C%3E%22%2C.%2F%3F@localhost:3306/test' AS secret_attach (TYPE MYSQL)
+----
+passwd="Aa1 ~`!@#$%^&*()_+-={}[]|\\;:'<>\",./?"


### PR DESCRIPTION
This PR is a continuation of #159.