### PR TITLE
Display only attach path in connection error

### DIFF
--- a/src/include/mysql_connection.hpp
+++ b/src/include/mysql_connection.hpp
@@ -41,8 +41,7 @@ struct OwnedMySQLConnection {
 
 class MySQLConnection {
 public:
-	explicit MySQLConnection(shared_ptr<OwnedMySQLConnection> connection, const std::string &dsn_p,
-	                         MySQLTypeConfig type_config_p);
+	explicit MySQLConnection(shared_ptr<OwnedMySQLConnection> connection, MySQLTypeConfig type_config_p);
 	~MySQLConnection();
 	// disable copy constructors
 	MySQLConnection(const MySQLConnection &other) = delete;
@@ -52,7 +51,8 @@ public:
 	MySQLConnection &operator=(MySQLConnection &&) noexcept;
 
 public:
-	static MySQLConnection Open(MySQLTypeConfig type_config, const string &connection_string);
+	static MySQLConnection Open(MySQLTypeConfig type_config, const string &connection_string,
+	                            const string &attach_path);
 	void Execute(const string &query);
 	void Execute(const string &query, vector<Value> params);
 	unique_ptr<MySQLResult> Query(const string &query, MySQLResultStreaming streaming);
@@ -65,9 +65,6 @@ public:
 
 	shared_ptr<OwnedMySQLConnection> GetConnection() {
 		return connection;
-	}
-	string GetDSN() {
-		return dsn;
 	}
 
 	MYSQL *GetConn() {
@@ -87,7 +84,6 @@ private:
 
 	mutex query_lock;
 	shared_ptr<OwnedMySQLConnection> connection;
-	string dsn;
 	MySQLTypeConfig type_config;
 };
 

--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -40,7 +40,7 @@ enum class MySQLConnectorInterface { UNINITIALIZED, BASIC, PREPARED_STATEMENT };
 class MySQLUtils {
 public:
 	static std::tuple<MySQLConnectionParameters, unordered_set<string>> ParseConnectionParameters(const string &dsn);
-	static MYSQL *Connect(const string &dsn);
+	static MYSQL *Connect(const string &dsn, const string &attach_path);
 
 	static string WriteIdentifier(const string &identifier);
 	static string WriteLiteral(const string &identifier);

--- a/src/mysql_connection.cpp
+++ b/src/mysql_connection.cpp
@@ -12,9 +12,8 @@ namespace duckdb {
 
 static bool debug_mysql_print_queries = false;
 
-MySQLConnection::MySQLConnection(shared_ptr<OwnedMySQLConnection> connection_p, const std::string &dsn_p,
-                                 MySQLTypeConfig type_config_p)
-    : connection(std::move(connection_p)), dsn(std::move(dsn_p)), type_config(std::move(type_config_p)) {
+MySQLConnection::MySQLConnection(shared_ptr<OwnedMySQLConnection> connection_p, MySQLTypeConfig type_config_p)
+    : connection(std::move(connection_p)), type_config(std::move(type_config_p)) {
 }
 
 MySQLConnection::~MySQLConnection() {
@@ -23,20 +22,19 @@ MySQLConnection::~MySQLConnection() {
 
 MySQLConnection::MySQLConnection(MySQLConnection &&other) noexcept {
 	std::swap(connection, other.connection);
-	std::swap(dsn, other.dsn);
 	std::swap(type_config, other.type_config);
 }
 
 MySQLConnection &MySQLConnection::operator=(MySQLConnection &&other) noexcept {
 	std::swap(connection, other.connection);
-	std::swap(dsn, other.dsn);
 	std::swap(type_config, other.type_config);
 	return *this;
 }
 
-MySQLConnection MySQLConnection::Open(MySQLTypeConfig type_config, const string &connection_string) {
-	auto connection = make_shared_ptr<OwnedMySQLConnection>(MySQLUtils::Connect(connection_string));
-	return MySQLConnection(std::move(connection), connection_string, std::move(type_config));
+MySQLConnection MySQLConnection::Open(MySQLTypeConfig type_config, const string &connection_string,
+                                      const string &attach_path) {
+	auto connection = make_shared_ptr<OwnedMySQLConnection>(MySQLUtils::Connect(connection_string, attach_path));
+	return MySQLConnection(std::move(connection), std::move(type_config));
 }
 
 idx_t MySQLConnection::MySQLExecute(MYSQL_STMT *stmt, const string &query, vector<Value> params, bool streaming) {

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -245,7 +245,7 @@ void SetMySQLOption(MYSQL *mysql, enum mysql_option option, const string &value)
 	}
 }
 
-MYSQL *MySQLUtils::Connect(const string &dsn) {
+MYSQL *MySQLUtils::Connect(const string &dsn, const string &attach_path) {
 	MYSQL *mysql = mysql_init(NULL);
 	if (!mysql) {
 		throw IOException("Failure in mysql_init");
@@ -287,12 +287,12 @@ MYSQL *MySQLUtils::Connect(const string &dsn) {
 				throw IOException("Failed to connect to MySQL database with parameters "
 				                  "\"%s\": %s. First attempted host: %s. "
 				                  "Retry with 127.0.0.1 also failed.",
-				                  dsn, mysql_error(mysql), attempted_host.c_str());
+				                  attach_path, mysql_error(mysql), attempted_host.c_str());
 			}
 		} else {
 			throw IOException("Failed to connect to MySQL database with parameters "
 			                  "\"%s\": %s. Attempted host: %s",
-			                  dsn, original_error.c_str(), attempted_host.c_str());
+			                  attach_path, original_error.c_str(), attempted_host.c_str());
 		}
 	}
 	if (mysql_set_character_set(mysql, "utf8mb4") != 0) {

--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -25,7 +25,7 @@ MySQLCatalog::MySQLCatalog(AttachedDatabase &db_p, string connection_string_p, s
 	default_schema = connection_params.db;
 	// try to connect
 	MySQLTypeConfig type_config;
-	auto connection = MySQLConnection::Open(type_config, connection_string);
+	auto connection = MySQLConnection::Open(type_config, connection_string, attach_path);
 }
 
 MySQLCatalog::~MySQLCatalog() = default;

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -12,7 +12,8 @@ namespace duckdb {
 
 MySQLTransaction::MySQLTransaction(MySQLCatalog &mysql_catalog, TransactionManager &manager, ClientContext &context)
     : Transaction(manager, context),
-      connection(MySQLConnection::Open(MySQLTypeConfig(context), mysql_catalog.connection_string)),
+      connection(
+          MySQLConnection::Open(MySQLTypeConfig(context), mysql_catalog.connection_string, mysql_catalog.attach_path)),
       access_mode(mysql_catalog.access_mode) {
 	string time_zone;
 	{

--- a/test/sql/attach_secret.test
+++ b/test/sql/attach_secret.test
@@ -77,3 +77,16 @@ statement error
 ATTACH '' AS secret_attach (TYPE MYSQL, SECRET unknown_secret)
 ----
 unknown_secret
+
+# check secret details not included into error message
+statement ok
+CREATE SECRET mysql_failure_secret (
+	TYPE MYSQL,
+	USER root,
+	PASSWORD root
+);
+
+statement error
+ATTACH 'host=127.0.0.1 database=unknown_db' AS failure_secret_attach (TYPE MYSQL, SECRET mysql_failure_secret)
+----
+Failed to connect to MySQL database with parameters "host=127.0.0.1 database=unknown_db"

--- a/test/sql/attach_uri.test
+++ b/test/sql/attach_uri.test
@@ -67,7 +67,8 @@ ATTACH 'mysql://root@localhost?attribute_with_escape_codes_%20%3C%3E%23%25%2B%7B
 ----
 attribute_with_escape_codes_ <>#%+{}|\^~[]`;/?:@=&$%XX%
 
-statement error
-ATTACH 'mysql://testuser:Aa1%20~%60%21%40%23$%25%5E%26%2A%28%29_%2B-%3D%7B%7D%5B%5D%7C%5C%3B%3A%27%3C%3E%22%2C.%2F%3F@localhost:3306/test' AS secret_attach (TYPE MYSQL)
-----
-passwd="Aa1 ~`!@#$%^&*()_+-={}[]|\\;:'<>\",./?"
+# parsed connection string is no longer displayed
+# statement error
+# ATTACH 'mysql://testuser:Aa1%20~%60%21%40%23$%25%5E%26%2A%28%29_%2B-%3D%7B%7D%5B%5D%7C%5C%3B%3A%27%3C%3E%22%2C.%2F%3F@localhost:3306/test' AS secret_attach (TYPE MYSQL)
+# ----
+# passwd="Aa1 ~`!@#$%^&*()_+-={}[]|\\;:'<>\",./?"


### PR DESCRIPTION
This change is a counterpart of the duckdb/duckdb-postgres#383 change.

Testing: new test added that checks error message, existing URI test is is disabled because the attach path is now diplayed in unparsed form.