### PR TITLE
Do not convert zero TIME to NULL

### DIFF
--- a/test/sql/attach_zero_date.test
+++ b/test/sql/attach_zero_date.test
@@ -15,7 +15,7 @@ SET mysql_time_as_time = TRUE
 query IIIII
 SELECT * FROM simple.zero_date
 ----
-NULL	NULL	NULL	NULL	0
+NULL	NULL	NULL	00:00:00	0
 
 statement ok
 SET mysql_time_as_time = FALSE
@@ -23,4 +23,4 @@ SET mysql_time_as_time = FALSE
 query IIIII
 SELECT * FROM simple.zero_date
 ----
-NULL	NULL	NULL	NULL	0
+NULL	NULL	NULL	00:00:00	0

--- a/test/sql/scan_datetime.test
+++ b/test/sql/scan_datetime.test
@@ -52,6 +52,16 @@ SELECT * FROM scan_datetime_1 ORDER BY col1
 ----
 1	2020-12-31
 
+query I
+SELECT * FROM mysql_query('msql', 'SELECT CAST(''0000-00-00'' AS DATE)')
+----
+NULL
+
+query I
+SELECT * FROM mysql_query('msql', 'SELECT CAST(''0000-00-00 00:00:00'' AS DATETIME)')
+----
+NULL
+
 # enable TIME type
 statement ok
 SET mysql_time_as_time = TRUE
@@ -109,6 +119,11 @@ SELECT typeof(col2) FROM scan_datetime_2
 TIME
 TIME
 
+query I
+SELECT * FROM mysql_query('msql', 'SELECT CAST(''00:00:00'' AS TIME)')
+----
+00:00:00
+
 # disable TIME type
 statement ok
 SET mysql_time_as_time = FALSE
@@ -146,3 +161,8 @@ VARCHAR
 
 statement ok
 DROP TABLE IF EXISTS scan_datetime_3
+
+query I
+SELECT * FROM mysql_query('msql', 'SELECT CAST(''00:00:00'' AS TIME)')
+----
+00:00:00


### PR DESCRIPTION
In MySQL/MariaDB C connector the `DATE`, `TIME`, `DATETIME` and `TIMESTAMP` values are fetched using the same `MYSQL_TIME` struct:

```c
typedef struct st_mysql_time
{
  unsigned int  year, month, day, hour, minute, second;
  unsigned long second_part;
  my_bool       neg;
  enum enum_mysql_timestamp_type time_type;
} MYSQL_TIME;
```

The scanner has implemented the following note from the connector documentation:

> "Zero" date or time values used through Connector/ODBC are converted automatically to NULL because ODBC cannot handle such values.

It appeared that outside of ODBC (that is not used by the scanner) MySQL treats "zero" values as `NULL`s for `DATE`, `DATETIME` and `TIMESTAMP` values, but not for `TIME` values.

This change removes the logic that treats `00:00:00` `TIME` values as `NULL`s. So '00:00:00' can now be returned to client.

Note, that MySQL `TIME` can be mapped either to DuckDB `TIME` or `VARCHAR` types (depending on `mysql_time_as_time` option added in #142), this change applies to both types.

Testing: new tests added for "zero" temporal values.

Ref: duckdblabs/duckdb-internal#6614