### PR TITLE
Add an option to disable transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ SELECT * FROM mysql_db.tmp;
 | mysql_bit1_as_boolean              | Whether or not to convert BIT(1) columns to BOOLEAN            | true    |
 | mysql_session_time_zone            | Value to use as a session time zone for newly opened connections to MySQL server | ''    |
 | mysql_time_as_time                 | Whether or not to convert MySQL's TIME columns to DuckDB's TIME | false   |
+| mysql_enable_transactions          | Whether to run `START TRANSACTION`/`COMMIT`/`ROLLBACK` on MySQL connections | true   |
 
 ## Schema Cache
 

--- a/src/include/storage/mysql_transaction.hpp
+++ b/src/include/storage/mysql_transaction.hpp
@@ -36,6 +36,7 @@ public:
 
 private:
 	MySQLConnection connection;
+	bool transactions_enabled = true;
 	MySQLTransactionState transaction_state;
 	AccessMode access_mode;
 };

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -126,6 +126,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("mysql_time_as_time", "Whether or not to convert MySQL's TIME columns to DuckDB's TIME",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false),
 	                          MySQLClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption("mysql_enable_transactions",
+	                          "Whether to run 'START TRANSACTION'/'COMMIT'/'ROLLBACK' on MySQL connections",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), MySQLClearCacheFunction::ClearCacheOnSetting);
 
 	OptimizerExtension mysql_optimizer;
 	mysql_optimizer.optimize_function = MySQLOptimizer::Optimize;

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -15,12 +15,16 @@ MySQLTransaction::MySQLTransaction(MySQLCatalog &mysql_catalog, TransactionManag
       connection(
           MySQLConnection::Open(MySQLTypeConfig(context), mysql_catalog.connection_string, mysql_catalog.attach_path)),
       access_mode(mysql_catalog.access_mode) {
+
+	Value mysql_enable_transactions; // by default transactions are enabled
+	if (context.TryGetCurrentSetting("mysql_enable_transactions", mysql_enable_transactions)) {
+		this->transactions_enabled = BooleanValue::Get(mysql_enable_transactions);
+	}
+
 	string time_zone;
-	{
-		Value mysql_session_time_zone;
-		if (context.TryGetCurrentSetting("mysql_session_time_zone", mysql_session_time_zone)) {
-			time_zone = mysql_session_time_zone.ToString();
-		}
+	Value mysql_session_time_zone;
+	if (context.TryGetCurrentSetting("mysql_session_time_zone", mysql_session_time_zone)) {
+		time_zone = mysql_session_time_zone.ToString();
 	}
 	if (!time_zone.empty()) {
 		connection.Execute("SET TIME_ZONE = '" + time_zone + "'");
@@ -33,20 +37,20 @@ void MySQLTransaction::Start() {
 	transaction_state = MySQLTransactionState::TRANSACTION_NOT_YET_STARTED;
 }
 void MySQLTransaction::Commit() {
-	if (transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
+	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
 		transaction_state = MySQLTransactionState::TRANSACTION_FINISHED;
 		connection.Execute("COMMIT");
 	}
 }
 void MySQLTransaction::Rollback() {
-	if (transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
+	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
 		transaction_state = MySQLTransactionState::TRANSACTION_FINISHED;
 		connection.Execute("ROLLBACK");
 	}
 }
 
 MySQLConnection &MySQLTransaction::GetConnection() {
-	if (transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
+	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
 		transaction_state = MySQLTransactionState::TRANSACTION_STARTED;
 		string query = "START TRANSACTION";
 		if (access_mode == AccessMode::READ_ONLY) {
@@ -58,7 +62,7 @@ MySQLConnection &MySQLTransaction::GetConnection() {
 }
 
 unique_ptr<MySQLResult> MySQLTransaction::Query(const string &query) {
-	if (transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
+	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
 		transaction_state = MySQLTransactionState::TRANSACTION_STARTED;
 		string transaction_start = "START TRANSACTION";
 		if (access_mode == AccessMode::READ_ONLY) {

--- a/test/sql/scan_no_transaction.test
+++ b/test/sql/scan_no_transaction.test
@@ -1,0 +1,30 @@
+# name: test/sql/scan_no_transaction.test
+# description: Test scan and remote queries with MySQL transactions disabled
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+SET mysql_enable_transactions = FALSE
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS mysqldb (TYPE MYSQL_SCANNER)
+
+query IIIII
+SELECT * FROM mysql_query('mysqldb', 'SELECT * FROM decimals')
+----
+0.5	1234.1	12345678.12	12345678901234567.123	1.2345678901234568e+35
+-0.5	-1234.1	-12345678.12	-12345678901234567.123	-1.2345678901234568e+35
+NULL	NULL	NULL	NULL	NULL
+
+query IIIII
+SELECT * FROM mysqldb.decimals
+----
+0.5	1234.1	12345678.12	12345678901234567.123	1.2345678901234568e+35
+-0.5	-1234.1	-12345678.12	-12345678901234567.123	-1.2345678901234568e+35
+NULL	NULL	NULL	NULL	NULL
+
+statement ok
+SET mysql_enable_transactions = TRUE


### PR DESCRIPTION
This PR adds an option `mysql_enable_transactions` that allows to run queries in MySQL without automatically wrapping them into `START TRANSACTION [READ ONLY]`/`COMMIT`/`ROLLBACK`:

```sql
SET mysql_enable_transactions = FALSE
```

This may be useful when connecting to another DBMS that uses MySQL wire protocol, but does not support transactions.

By default transactions are enabled.

This option is not intended to be used when `ATTACH` is performed with MySQL or MariaDB servers.

Testing: new test is added that checks existing data reading with transactions disabled.

Fixes: #19