### PR TITLE
Do not fetch full result set on close

### DIFF
--- a/src/include/mysql_connection.hpp
+++ b/src/include/mysql_connection.hpp
@@ -27,8 +27,10 @@ class MySQLResult;
 struct IndexInfo;
 
 struct OwnedMySQLConnection {
+
 	explicit OwnedMySQLConnection(MYSQL *conn = nullptr) : connection(conn) {
 	}
+
 	~OwnedMySQLConnection() {
 		if (!connection) {
 			return;
@@ -37,12 +39,20 @@ struct OwnedMySQLConnection {
 		connection = nullptr;
 	}
 
+	unsigned long GetID() {
+		if (!connection) {
+			return 0;
+		}
+		return mysql_thread_id(connection);
+	}
+
 	MYSQL *connection;
 };
 
 class MySQLConnection {
 public:
-	explicit MySQLConnection(shared_ptr<OwnedMySQLConnection> connection, MySQLTypeConfig type_config_p);
+	explicit MySQLConnection(shared_ptr<OwnedMySQLConnection> connection, MySQLTypeConfig type_config_p,
+	                         const string &connection_string);
 	~MySQLConnection();
 	// disable copy constructors
 	MySQLConnection(const MySQLConnection &other) = delete;
@@ -89,6 +99,7 @@ private:
 	mutex query_lock;
 	shared_ptr<OwnedMySQLConnection> connection;
 	MySQLTypeConfig type_config;
+	string connection_string;
 };
 
 } // namespace duckdb

--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -26,7 +26,10 @@ inline void MySQLResultDelete(MYSQL_RES *res) {
 class MySQLResult {
 public:
 	MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, MySQLTypeConfig type_config_p,
+	            const string &connection_string_p, unsigned long connection_id_p, MySQLResultStreaming streaming_p,
 	            idx_t affected_rows_p, vector<MySQLField> fields_p = vector<MySQLField>());
+
+	~MySQLResult();
 
 	string GetString(idx_t col);
 	int32_t GetInt32(idx_t col);
@@ -42,12 +45,16 @@ private:
 	string query;
 	MySQLStatementPtr stmt;
 	MySQLTypeConfig type_config;
+	string connection_string;
+	unsigned long connection_id;
+	MySQLResultStreaming streaming;
 	idx_t affected_rows = static_cast<idx_t>(-1);
 
 	vector<MySQLField> fields;
 
 	DataChunk data_chunk;
 	idx_t row_idx = static_cast<idx_t>(-1);
+	bool exhausted = false;
 
 	bool FetchNext();
 	void HandleTruncatedData();
@@ -55,6 +62,7 @@ private:
 	void CheckColumnIdx(idx_t col);
 	void CheckNotNull(idx_t col);
 	void CheckType(idx_t col, LogicalTypeId type_id);
+	bool TryCancelQuery();
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Unlike the Simple API, the Prepared Statement API does not require the client (scanner) to read all the results before closing the result set. Instead it is doing that under the hood in `mysql_stmt_close` call. With large result set this can be time consuming and for end-user looks like the query is hanging.

This PR re-implements the "reconnect+kill" approach from #136 for prepared statements. When the query is run in streaming mode (see notes on streaming in [this comment](https://github.com/duckdb/duckdb-mysql/issues/55#issuecomment-3607311166)) there are 2 scenarios:

1. the subsequent query is run on the same connection without reading all the result from the previous query

2. the running query is interrupted (using `Connection->Interrrup()` or its client-specific wrapper) from another thread

In both cases the second connection to MySQL server is established and `KILL QUERY <ID>` command is run on that connection.

Unlike the #136, this change does not swap the underlying MySQL connection to a new one:

 - the cleanup in `mysql_stmt_close` after `KILL QUERY` leaves the MySQL connection in a valid state
 - when the query is interrupted (that causes the transaction abort) or when the auto-commit is enabled - the following queries on the same DuckDB connection will open new MySQL connections
 - so the actual connection reuse after the query killed on this connection happens only when the result set is abandoned (not exhausted) and the subsequent query is run on the same connection in the same transaction.

Note, that language clients may have their own restrictions on result set streaming, for example, in JDBC the streaming is disabled by default.

Testing: the query abandon (or interrupt) logic is not supported by `sqllogictest` test suite. The scenarios above are tested manually with TPC-H data.