### PR TITLE
Change bind type for GEOMETRY columns

### DIFF
--- a/src/mysql_field.cpp
+++ b/src/mysql_field.cpp
@@ -45,7 +45,12 @@ void MySQLField::ResetBind() {
 MYSQL_BIND MySQLField::CreateBindStruct() {
 	MYSQL_BIND b;
 	std::memset(&b, '\0', sizeof(MYSQL_BIND));
-	b.buffer_type = mysql_type;
+	enum_field_types bind_type = mysql_type;
+	// see https://github.com/duckdb/duckdb-mysql/issues/188
+	if (bind_type == MYSQL_TYPE_GEOMETRY) {
+		bind_type = MYSQL_TYPE_VAR_STRING;
+	}
+	b.buffer_type = bind_type;
 	b.buffer = bind_buffer.data();
 	b.buffer_length = static_cast<unsigned long>(bind_buffer.size());
 	b.is_null = &bind_is_null;

--- a/test/sql/attach_mariadb_geometry.test
+++ b/test/sql/attach_mariadb_geometry.test
@@ -8,8 +8,6 @@ require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 require-env MARIADB_SERVER
 
-require-env TEMPORARY_DISABLED
-
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
 

--- a/test/sql/attach_mysql_geometry.test
+++ b/test/sql/attach_mysql_geometry.test
@@ -8,8 +8,6 @@ require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 require-env ORACLE_MYSQL_SERVER
 
-require-env TEMPORARY_DISABLED
-
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
 


### PR DESCRIPTION
Unlike `libmariadb` in 1.5, the `libmysql` that is used in 1.4.x does not accept binding `GEOMETRY` columns to `MYSQL_TYPE_GEOMETRY`.

This PR changes it to generic `MYSQL_TYPE_VAR_STRING`, only applied to 1.4 branch.

Testing: existing geometry tests are enabled back for both MySQL and MariaDB servers.

Fixes: #188