### PR TITLE
Exit early when result set is exhausted

### DIFF
--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -38,6 +38,7 @@ public:
 
 	DataChunk &NextChunk();
 	bool Next();
+	bool Exhausted();
 	idx_t AffectedRows();
 	const vector<MySQLField> &Fields();
 

--- a/src/mysql_result.cpp
+++ b/src/mysql_result.cpp
@@ -133,6 +133,10 @@ DataChunk &MySQLResult::NextChunk() {
 	return this->data_chunk;
 }
 
+bool MySQLResult::Exhausted() {
+	return this->exhausted;
+}
+
 bool MySQLResult::FetchNext() {
 	for (auto &f : fields) {
 #ifdef DEBUG

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -77,6 +77,11 @@ static unique_ptr<LocalTableFunctionState> MySQLInitLocalState(ExecutionContext 
 
 static void MySQLScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
 	auto &gstate = data.global_state->Cast<MySQLGlobalState>();
+	if (gstate.result->Exhausted()) {
+		output.SetCardinality(0);
+		return;
+	}
+
 	DataChunk &res_chunk = gstate.result->NextChunk();
 	D_ASSERT(output.ColumnCount() == res_chunk.ColumnCount());
 	string error;


### PR DESCRIPTION
When the result set is read completely, currently there is an additional call to `mysql_stmt_fetch` performed before returning completion to the engine.

This PR adds a check to return early in this case.

Testing: no functional changes, no new tests, large result sets are tested manually on TPC-H data.