### PR TITLE
fix: concurrent mysql catalog loading

### DIFF
--- a/src/include/storage/mysql_catalog_set.hpp
+++ b/src/include/storage/mysql_catalog_set.hpp
@@ -30,6 +30,8 @@ public:
 protected:
 	virtual void LoadEntries(ClientContext &context) = 0;
 
+	void TryLoadEntries(ClientContext &context);
+
 	void EraseEntryInternal(const string &name);
 
 protected:
@@ -37,8 +39,9 @@ protected:
 
 private:
 	mutex entry_lock;
+	mutex load_lock;
 	case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
-	bool is_loaded;
+	atomic<bool> is_loaded;
 };
 
 class MySQLInSchemaSet : public MySQLCatalogSet {

--- a/src/storage/mysql_catalog_set.cpp
+++ b/src/storage/mysql_catalog_set.cpp
@@ -9,16 +9,22 @@ MySQLCatalogSet::MySQLCatalogSet(Catalog &catalog) : catalog(catalog), is_loaded
 }
 
 optional_ptr<CatalogEntry> MySQLCatalogSet::GetEntry(ClientContext &context, const string &name) {
-	if (!is_loaded) {
-		is_loaded = true;
-		LoadEntries(context);
-	}
+	TryLoadEntries(context);
 	lock_guard<mutex> l(entry_lock);
 	auto entry = entries.find(name);
 	if (entry == entries.end()) {
 		return nullptr;
 	}
 	return entry->second.get();
+}
+
+void MySQLCatalogSet::TryLoadEntries(ClientContext &context) {
+	lock_guard<mutex> l(load_lock);
+	if (is_loaded) {
+		return;
+	}
+	is_loaded = true;
+	LoadEntries(context);
 }
 
 void MySQLCatalogSet::DropEntry(ClientContext &context, DropInfo &info) {
@@ -46,10 +52,7 @@ void MySQLCatalogSet::EraseEntryInternal(const string &name) {
 }
 
 void MySQLCatalogSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
-	if (!is_loaded) {
-		is_loaded = true;
-		LoadEntries(context);
-	}
+	TryLoadEntries(context);
 	lock_guard<mutex> l(entry_lock);
 	for (auto &entry : entries) {
 		callback(*entry.second);
@@ -67,6 +70,7 @@ optional_ptr<CatalogEntry> MySQLCatalogSet::CreateEntry(unique_ptr<CatalogEntry>
 }
 
 void MySQLCatalogSet::ClearEntries() {
+	lock_guard<mutex> l(entry_lock);
 	entries.clear();
 	is_loaded = false;
 }


### PR DESCRIPTION
This fixes race condition and issue when clearing and loading mysql catalog from multiple threads.

This was observed since 1.3 in a go binding, when multiple threads/ routines where creating new mysql shemas, calling `mysql_clear_cache`, and attempting to insert into them.

This follows same pattern as duckdb-postgresql extension by introducing load mutex, and guarding loading.

https://github.com/duckdb/duckdb-postgres/blob/b9fce43bc5d36bc6db70844f28b7b146e756eb22/src/include/storage/postgres_catalog_set.hpp#L50

This is reproducable on main.

To reproduce:
1. Attach mysql db
2. Call mysql_clear_cache()
3. Start N threads and call begin in each one.
4. Each threads attempts to INSERT INTO table.
5. Some thread(s) will fail with schema/table not found.