### PR TITLE
Use dedicated connection for mysql_query streaming

### DIFF
--- a/src/include/mysql_connection_pool.hpp
+++ b/src/include/mysql_connection_pool.hpp
@@ -15,6 +15,10 @@
 
 namespace duckdb {
 
+enum class MySQLPoolAcquireMode : uint8_t { FORCE, WAIT, TRY };
+
+using MySQLPooledConnection = dbconnector::pool::PooledConnection<MySQLConnection>;
+
 class MySQLConnectionPool : public dbconnector::pool::ConnectionPool<MySQLConnection> {
 public:
 	MySQLConnectionPool(ClientContext &context, string connection_string, string attach_path);
@@ -26,6 +30,8 @@ public:
 	void EnsureCalibrated(MySQLConnection &conn);
 	void SetNetworkCompression(bool enabled, double ratio = NetworkCalibration::DEFAULT_COMPRESSION_RATIO);
 	static idx_t DefaultPoolSize() noexcept;
+	MySQLPooledConnection Acquire(MySQLPoolAcquireMode acquire_mode, const std::string &time_zone = std::string());
+	static MySQLPoolAcquireMode GetAcquireMode(ClientContext &context);
 
 protected:
 	std::unique_ptr<MySQLConnection> CreateNewConnection() override;

--- a/src/include/mysql_scanner.hpp
+++ b/src/include/mysql_scanner.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 
 #include "mysql_connection.hpp"
+#include "mysql_connection_pool.hpp"
 #include "mysql_statement.hpp"
 #include "mysql_types.hpp"
 #include "mysql_utils.hpp"
@@ -47,24 +48,22 @@ public:
 };
 
 struct MySQLQueryBindData : public FunctionData {
-	MySQLQueryBindData(Catalog &catalog, unique_ptr<MySQLStatement> stmt_p, vector<Value> params_p, string query_p,
-	                   MySQLResultStreaming streaming_p)
-	    : catalog(catalog), stmt(std::move(stmt_p)), params(std::move(params_p)), query(std::move(query_p)),
-	      user_streaming(streaming_p) {
+	MySQLQueryBindData(string query_p, Catalog &catalog, MySQLPooledConnection pooled_connection_p,
+	                   unique_ptr<MySQLStatement> stmt_p, vector<Value> params_p)
+	    : query(std::move(query_p)), catalog(catalog), pooled_connection(std::move(pooled_connection_p)),
+	      stmt(std::move(stmt_p)), params(std::move(params_p)) {
 	}
 
-	MySQLQueryBindData(Catalog &catalog, unique_ptr<MySQLResult> result_p, string query_p,
-	                   MySQLResultStreaming streaming_p)
-	    : catalog(catalog), result(std::move(result_p)), query(std::move(query_p)), user_streaming(streaming_p) {
+	MySQLQueryBindData(string query_p, Catalog &catalog, unique_ptr<MySQLResult> result_p)
+	    : query(std::move(query_p)), catalog(catalog), pooled_connection(), result(std::move(result_p)) {
 	}
 
+	string query;
 	Catalog &catalog;
+	MySQLPooledConnection pooled_connection;
 	unique_ptr<MySQLResult> result;
 	unique_ptr<MySQLStatement> stmt;
 	vector<Value> params;
-	string query;
-	MySQLResultStreaming user_streaming = MySQLResultStreaming::UNINITIALIZED;
-	MySQLResultStreaming streaming = MySQLResultStreaming::UNINITIALIZED;
 
 public:
 	unique_ptr<FunctionData> Copy() const override {

--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -43,7 +43,7 @@ struct MySQLConnectionParameters {
 	string ssl_key;
 };
 
-enum class MySQLResultStreaming { UNINITIALIZED, ALLOW_STREAMING, FORCE_MATERIALIZATION, REQUIRE_STREAMING };
+enum class MySQLResultStreaming { UNINITIALIZED, ALLOW_STREAMING, FORCE_MATERIALIZATION };
 
 enum class MySQLConnectorInterface { UNINITIALIZED, BASIC, PREPARED_STATEMENT };
 

--- a/src/include/storage/mysql_transaction.hpp
+++ b/src/include/storage/mysql_transaction.hpp
@@ -18,8 +18,6 @@ class MySQLTableEntry;
 
 enum class MySQLTransactionState { TRANSACTION_NOT_YET_STARTED, TRANSACTION_STARTED, TRANSACTION_FINISHED };
 
-enum class MySQLPoolAcquireMode : uint8_t { FORCE, WAIT, TRY };
-
 class MySQLTransaction : public Transaction {
 public:
 	MySQLTransaction(MySQLCatalog &mysql_catalog, TransactionManager &manager, ClientContext &context);
@@ -40,7 +38,7 @@ private:
 	void EnsureConnection();
 
 	MySQLCatalog &catalog;
-	dbconnector::pool::PooledConnection<MySQLConnection> pooled_connection;
+	MySQLPooledConnection pooled_connection;
 	bool transactions_enabled = true;
 	MySQLTransactionState transaction_state = MySQLTransactionState::TRANSACTION_NOT_YET_STARTED;
 	AccessMode access_mode;

--- a/src/mysql_connection_pool.cpp
+++ b/src/mysql_connection_pool.cpp
@@ -200,4 +200,50 @@ dbconnector::pool::ConnectionPoolConfig MySQLConnectionPool::CreateConfig(Client
 	return config;
 }
 
+MySQLPooledConnection MySQLConnectionPool::Acquire(MySQLPoolAcquireMode acquire_mode, const std::string &time_zone) {
+	MySQLPooledConnection pc;
+	switch (acquire_mode) {
+	case MySQLPoolAcquireMode::FORCE:
+		pc = ForceAcquire();
+		break;
+	case MySQLPoolAcquireMode::WAIT:
+		pc = WaitAcquire();
+		break;
+	case MySQLPoolAcquireMode::TRY:
+		pc = TryAcquire();
+		if (!pc) {
+			throw IOException("Connection pool exhausted: no connections available (try mode)");
+		}
+		break;
+	}
+
+	if (!time_zone.empty()) {
+		try {
+			pc->Execute("SET TIME_ZONE = ?", {Value(time_zone)});
+		} catch (...) {
+			pc.Invalidate();
+			throw;
+		}
+	}
+
+	return pc;
+}
+
+MySQLPoolAcquireMode MySQLConnectionPool::GetAcquireMode(ClientContext &context) {
+	Value mode_val;
+	if (context.TryGetCurrentSetting("mysql_pool_acquire_mode", mode_val)) {
+		auto mode_str = StringUtil::Lower(mode_val.ToString());
+		if (mode_str == "force") {
+			return MySQLPoolAcquireMode::FORCE;
+		} else if (mode_str == "wait") {
+			return MySQLPoolAcquireMode::WAIT;
+		} else if (mode_str == "try") {
+			return MySQLPoolAcquireMode::TRY;
+		} else {
+			throw IOException("Invalid unsupported acquire mode: '%s'", mode_str);
+		}
+	}
+	return MySQLPoolAcquireMode::FORCE;
+}
+
 } // namespace duckdb

--- a/src/mysql_result.cpp
+++ b/src/mysql_result.cpp
@@ -82,8 +82,7 @@ MySQLResult::MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, M
 }
 
 MySQLResult::~MySQLResult() {
-	bool stream_active =
-	    streaming == MySQLResultStreaming::ALLOW_STREAMING || streaming == MySQLResultStreaming::REQUIRE_STREAMING;
+	bool stream_active = streaming == MySQLResultStreaming::ALLOW_STREAMING;
 	if (stream_active && !exhausted) {
 		TryCancelQuery();
 	}

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "mysql_scanner.hpp"
 #include "mysql_result.hpp"
+#include "mysql_connection_pool.hpp"
 #include "storage/mysql_transaction.hpp"
 #include "storage/mysql_table_set.hpp"
 #include "storage/mysql_catalog.hpp"
@@ -621,7 +622,6 @@ static unique_ptr<FunctionData> MySQLQueryBind(ClientContext &context, TableFunc
 	if (catalog.GetCatalogType() != "mysql") {
 		throw BinderException("Attached database \"%s\" does not refer to a MySQL database", db_name);
 	}
-	auto &transaction = MySQLTransaction::Get(context, catalog);
 	auto sql = input.inputs[1].GetValue<string>();
 
 	vector<Value> params;
@@ -637,36 +637,44 @@ static unique_ptr<FunctionData> MySQLQueryBind(ClientContext &context, TableFunc
 		params = StructValue::GetChildren(struct_val);
 	}
 
-	MySQLResultStreaming streaming = MySQLResultStreaming::ALLOW_STREAMING;
+	bool streaming_enabled = true;
 	auto streaming_it = input.named_parameters.find("stream_results");
 	if (streaming_it != input.named_parameters.end()) {
 		Value &bool_val = streaming_it->second;
 		if (!bool_val.IsNull()) {
-			if (BooleanValue::Get(bool_val)) {
-				streaming = MySQLResultStreaming::REQUIRE_STREAMING;
-			} else {
-				streaming = MySQLResultStreaming::FORCE_MATERIALIZATION;
-			}
+			streaming_enabled = BooleanValue::Get(bool_val);
 		}
 	}
 
-	MySQLConnection &conn = transaction.GetConnection();
-
-	if (streaming == MySQLResultStreaming::FORCE_MATERIALIZATION) {
+	if (!streaming_enabled) {
+		auto &transaction = MySQLTransaction::Get(context, catalog);
+		MySQLConnection &conn = transaction.GetConnection();
 		auto result = conn.Query(sql, params, MySQLResultStreaming::FORCE_MATERIALIZATION);
 		for (auto &field : result->Fields()) {
 			names.push_back(field.name);
 			return_types.push_back(field.duckdb_type);
 		}
-		return make_uniq<MySQLQueryBindData>(catalog, std::move(result), std::move(sql), streaming);
+		return make_uniq<MySQLQueryBindData>(std::move(sql), catalog, std::move(result));
 	}
 
-	auto stmt = transaction.GetConnection().Prepare(sql);
+	auto &mysql_catalog = catalog.Cast<MySQLCatalog>();
+
+	auto acquire_mode = MySQLConnectionPool::GetAcquireMode(context);
+	std::string time_zone;
+	Value mysql_session_time_zone;
+	if (context.TryGetCurrentSetting("mysql_session_time_zone", mysql_session_time_zone)) {
+		time_zone = mysql_session_time_zone.ToString();
+	}
+	auto conn = mysql_catalog.GetConnectionPool().Acquire(acquire_mode, time_zone);
+	auto type_config = MySQLTypeConfig(context);
+	conn->SetTypeConfig(type_config);
+
+	auto stmt = conn->Prepare(sql);
 	for (auto &field : stmt->Fields()) {
 		names.push_back(field.name);
 		return_types.push_back(field.duckdb_type);
 	}
-	return make_uniq<MySQLQueryBindData>(catalog, std::move(stmt), std::move(params), std::move(sql), streaming);
+	return make_uniq<MySQLQueryBindData>(std::move(sql), catalog, std::move(conn), std::move(stmt), std::move(params));
 }
 
 static unique_ptr<GlobalTableFunctionState> MySQLQueryInitGlobalState(ClientContext &context,
@@ -683,15 +691,10 @@ static void MySQLQueryScan(ClientContext &context, TableFunctionInput &data, Dat
 	auto &gstate = data.global_state->Cast<MySQLGlobalState>();
 	if (!gstate.result) {
 		auto &bind_data = data.bind_data->CastNoConst<MySQLQueryBindData>();
-		if (bind_data.user_streaming == MySQLResultStreaming::REQUIRE_STREAMING &&
-		    bind_data.streaming != MySQLResultStreaming::ALLOW_STREAMING) {
-			throw IOException("Unable to stream results of 'mysql_query' function, ensure that each invocation with "
-			                  "'stream_results=TRUE' uses its own private connection");
-		}
-		auto &transaction = MySQLTransaction::Get(context, bind_data.catalog);
-		MySQLStatement &stmt = *bind_data.stmt;
-		const vector<Value> &params = bind_data.params;
-		auto result = transaction.GetConnection().Query(stmt, params, bind_data.streaming);
+		D_ASSERT(bind_data.pooled_connection);
+		D_ASSERT(bind_data.stmt);
+		auto result = bind_data.pooled_connection->Query(*bind_data.stmt, bind_data.params,
+		                                                 MySQLResultStreaming::ALLOW_STREAMING);
 		gstate.result = std::move(result);
 	}
 	MySQLScan(context, data, output);

--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -488,10 +488,6 @@ void MySQLCatalog::MaterializeMySQLScans(PhysicalOperator &op) {
 			auto &bind_data = table_scan.bind_data->Cast<MySQLBindData>();
 			bind_data.streaming = MySQLResultStreaming::FORCE_MATERIALIZATION;
 		}
-		if (MySQLCatalog::IsMySQLQuery(table_scan.function.name)) {
-			auto &bind_data = table_scan.bind_data->Cast<MySQLQueryBindData>();
-			bind_data.streaming = MySQLResultStreaming::FORCE_MATERIALIZATION;
-		}
 	}
 	for (auto &child : op.children) {
 		MaterializeMySQLScans(child);

--- a/src/storage/mysql_optimizer.cpp
+++ b/src/storage/mysql_optimizer.cpp
@@ -746,13 +746,6 @@ void MySQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<Logical
 					bind_data.streaming = result_streaming;
 				}
 			}
-			if (MySQLCatalog::IsMySQLQuery(get.function.name)) {
-				auto &bind_data = get.bind_data->Cast<MySQLQueryBindData>();
-				if (bind_data.streaming == MySQLResultStreaming::UNINITIALIZED ||
-				    result_streaming == MySQLResultStreaming::FORCE_MATERIALIZATION) {
-					bind_data.streaming = result_streaming;
-				}
-			}
 		}
 	}
 

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -24,17 +24,7 @@ MySQLTransaction::MySQLTransaction(MySQLCatalog &mysql_catalog, TransactionManag
 		time_zone = mysql_session_time_zone.ToString();
 	}
 
-	Value mysql_pool_acquire_mode;
-	if (context.TryGetCurrentSetting("mysql_pool_acquire_mode", mysql_pool_acquire_mode)) {
-		auto mode_str = StringUtil::Lower(mysql_pool_acquire_mode.ToString());
-		if (mode_str == "force") {
-			acquire_mode = MySQLPoolAcquireMode::FORCE;
-		} else if (mode_str == "wait") {
-			acquire_mode = MySQLPoolAcquireMode::WAIT;
-		} else if (mode_str == "try") {
-			acquire_mode = MySQLPoolAcquireMode::TRY;
-		}
-	}
+	acquire_mode = MySQLConnectionPool::GetAcquireMode(context);
 }
 
 MySQLTransaction::~MySQLTransaction() = default;
@@ -71,30 +61,7 @@ void MySQLTransaction::EnsureConnection() {
 	if (pooled_connection) {
 		return;
 	}
-	auto &pool = catalog.GetConnectionPool();
-	switch (acquire_mode) {
-	case MySQLPoolAcquireMode::FORCE:
-		pooled_connection = pool.ForceAcquire();
-		break;
-	case MySQLPoolAcquireMode::WAIT:
-		pooled_connection = pool.WaitAcquire();
-		break;
-	case MySQLPoolAcquireMode::TRY:
-		pooled_connection = pool.TryAcquire();
-		if (!pooled_connection) {
-			throw IOException("Connection pool exhausted: no connections available (try mode)");
-		}
-		break;
-	}
-
-	if (!time_zone.empty()) {
-		try {
-			pooled_connection.GetConnection().Execute("SET TIME_ZONE = ?", {Value(time_zone)});
-		} catch (...) {
-			pooled_connection.Invalidate();
-			throw;
-		}
-	}
+	pooled_connection = catalog.GetConnectionPool().Acquire(acquire_mode, time_zone);
 }
 
 MySQLConnection &MySQLTransaction::GetConnection() {

--- a/test/sql/mysql_query.test
+++ b/test/sql/mysql_query.test
@@ -212,12 +212,21 @@ SELECT * FROM mysql_query('simple', 'SELECT ?',
 ----
 foo
 
-statement error
+query I
+SELECT * FROM mysql_query('simple', 'SELECT 42 col1', stream_results=FALSE)
+UNION ALL
+SELECT * FROM mysql_query('simple', 'SELECT 43 col1', stream_results=FALSE)
+----
+42
+43
+
+query I
 SELECT * FROM mysql_query('simple', 'SELECT 42 col1', stream_results=TRUE)
 UNION ALL
-SELECT * FROM mysql_query('simple', 'SELECT 43 col1', stream_results=TRUE)
+SELECT * FROM mysql_query('simple', 'SELECT 43 col1', stream_results=FALSE)
 ----
-Unable to stream results
+42
+43
 
 query I
 SELECT * FROM mysql_query('simple', 'SELECT 42 col1', stream_results=NULL)
@@ -228,12 +237,4 @@ SELECT * FROM mysql_query('simple', 'SELECT 43 col1', stream_results=NULL)
 43
 
 statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS simple2 (TYPE MYSQL_SCANNER)
-
-query I
-SELECT * FROM mysql_query('simple', 'SELECT 42 col1', stream_results=TRUE)
-UNION ALL
-SELECT * FROM mysql_query('simple2', 'SELECT 43 col1', stream_results=TRUE)
-----
-42
-43
+DETACH simple;


### PR DESCRIPTION
Existing logic for streaming results of `mysql_query` function, when the same connection is expected to be present during both binding and execution, appeared to be problematic when transaction is restarted between bind and execute calls.

This PR changes the connection handling for `mysql_query` to acquire a dedicated connection from the connection pool and keep this connection until execution is complete.

If a dedicated connection is undesired, it is necesary to specify `stream_results=FALSE` named argument to `mysql_query`.

Testing: existing `mysql_query` tests are updated.

Fixes: #218