### PR TITLE
Change default connection pool settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ SELECT * FROM mysql_db.tmp;
 | mysql_time_as_time                 | Whether or not to convert MySQL's TIME columns to DuckDB's TIME | false  |
 | mysql_incomplete_dates_as_nulls    | Whether to return DATEs with zero month or day as NULLs        | false   |
 | mysql_enable_transactions          | Whether to run `START TRANSACTION`/`COMMIT`/`ROLLBACK` on MySQL connections | true   |
-| mysql_pool_size                    | Maximum number of connections per MySQL catalog (default: )    | min(cpu_count, 8) |
+| mysql_pool_size                    | Maximum number of connections per MySQL catalog (default: )    | 4 <= cpu_count * 1.5 <= 32 |
 | mysql_pool_wait_timeout_millis              | Timeout in milliseconds when waiting for a connection from the pool | 30000 |
 | mysql_pool_acquire_mode            | How to acquire connections from the pool: 'force' (always connect, ignore pool limit), 'wait' (block until available), 'try' (fail immediately if unavailable) | "force" |
-| mysql_pool_enable_thread_local_cache      | Enable thread-local connection caching for faster same-thread connection reuse | true |
+| mysql_pool_enable_thread_local_cache      | Enable thread-local connection caching for faster same-thread connection reuse | false |
 | mysql_pool_connection_max_lifetime_millis  | Maximum age of a pooled connection in milliseconds since it was first opened. When exceeded, the connection is closed instead of being returned to the cache| 0: disabled |
-| mysql_pool_connection_idle_timeout_millis | Maximum time in milliseconds a connection can sit idle in the cache before being closed | 0: disabled |
-| mysql_pool_enable_reaper_thread    | Whether to run a dedicated thread that periodically scans the pool and removes expired connections | false |
+| mysql_pool_connection_idle_timeout_millis | Maximum time in milliseconds a connection can sit idle in the cache before being closed | 60000 |
+| mysql_pool_enable_reaper_thread    | Whether to run a dedicated thread that periodically scans the pool and removes expired connections | true |
 | mysql_compression_aware_costs      | Apply compression ratios when estimating transfer costs        | true    |
 | mysql_compression_ratio            | Compression ratio for transfer cost estimation                 | 0.7     |
 | mysql_push_threshold_with_index    | Selectivity threshold for pushing filters with index support   | 0.5     |

--- a/src/include/mysql_connection_pool.hpp
+++ b/src/include/mysql_connection_pool.hpp
@@ -15,8 +15,6 @@
 
 namespace duckdb {
 
-enum class MySQLPoolAcquireMode : uint8_t { FORCE, WAIT, TRY };
-
 using MySQLPooledConnection = dbconnector::pool::PooledConnection<MySQLConnection>;
 
 class MySQLConnectionPool : public dbconnector::pool::ConnectionPool<MySQLConnection> {
@@ -30,8 +28,9 @@ public:
 	void EnsureCalibrated(MySQLConnection &conn);
 	void SetNetworkCompression(bool enabled, double ratio = NetworkCalibration::DEFAULT_COMPRESSION_RATIO);
 	static idx_t DefaultPoolSize() noexcept;
-	MySQLPooledConnection Acquire(MySQLPoolAcquireMode acquire_mode, const std::string &time_zone = std::string());
-	static MySQLPoolAcquireMode GetAcquireMode(ClientContext &context);
+	MySQLPooledConnection Acquire(dbconnector::pool::AcquireMode acquire_mode,
+	                              const std::string &time_zone = std::string());
+	static dbconnector::pool::AcquireMode GetAcquireMode(ClientContext &context);
 
 protected:
 	std::unique_ptr<MySQLConnection> CreateNewConnection() override;

--- a/src/include/storage/mysql_transaction.hpp
+++ b/src/include/storage/mysql_transaction.hpp
@@ -43,7 +43,7 @@ private:
 	MySQLTransactionState transaction_state = MySQLTransactionState::TRANSACTION_NOT_YET_STARTED;
 	AccessMode access_mode;
 	string time_zone;
-	MySQLPoolAcquireMode acquire_mode = MySQLPoolAcquireMode::FORCE;
+	dbconnector::pool::AcquireMode acquire_mode = dbconnector::pool::AcquireMode::FORCE;
 };
 
 } // namespace duckdb

--- a/src/mysql_connection_pool.cpp
+++ b/src/mysql_connection_pool.cpp
@@ -159,12 +159,6 @@ void MySQLConnectionPool::CalibrateNetwork(MySQLConnection &conn) {
 	}
 }
 
-idx_t MySQLConnectionPool::DefaultPoolSize() noexcept {
-	unsigned int hw = std::thread::hardware_concurrency();
-	idx_t detected = (hw == 0) ? 4u : static_cast<idx_t>(hw);
-	return detected < 8u ? detected : 8u;
-}
-
 static idx_t ReadUBigIntOption(ClientContext &ctx, const std::string &name, idx_t default_val) {
 	Value val;
 	if (ctx.TryGetCurrentSetting(name, val)) {
@@ -182,34 +176,30 @@ static bool ReadBooleanOption(ClientContext &ctx, const std::string &name, bool 
 }
 
 dbconnector::pool::ConnectionPoolConfig MySQLConnectionPool::CreateConfig(ClientContext &ctx) {
-	idx_t pool_size = ReadUBigIntOption(ctx, "mysql_pool_size", MySQLConnectionPool::DefaultPoolSize());
-	idx_t pool_timeout_ms = ReadUBigIntOption(ctx, "mysql_pool_wait_timeout_millis", 30000);
-	bool thread_local_cache_enabled = ReadBooleanOption(ctx, "mysql_pool_enable_thread_local_cache", true);
-	idx_t pool_connection_max_lifetime_ms = ReadUBigIntOption(ctx, "mysql_pool_connection_max_lifetime_millis", 0);
-	idx_t pool_connection_idle_timeout_ms = ReadUBigIntOption(ctx, "mysql_pool_connection_idle_timeout_millis", 0);
-	bool pool_enable_reaper_thread = ReadBooleanOption(ctx, "mysql_pool_enable_reaper_thread", false);
-
 	dbconnector::pool::ConnectionPoolConfig config;
-	config.max_connections = pool_size;
-	config.wait_timeout_millis = pool_timeout_ms;
-	config.tl_cache_enabled = thread_local_cache_enabled;
-	config.max_lifetime_millis = pool_connection_max_lifetime_ms;
-	config.idle_timeout_millis = pool_connection_idle_timeout_ms;
-	config.start_reaper_thread = pool_enable_reaper_thread;
+	config.max_connections = ReadUBigIntOption(ctx, "mysql_pool_size", config.max_connections);
+	config.wait_timeout_millis = ReadUBigIntOption(ctx, "mysql_pool_wait_timeout_millis", config.wait_timeout_millis);
+	config.tl_cache_enabled = ReadBooleanOption(ctx, "mysql_pool_enable_thread_local_cache", config.tl_cache_enabled);
+	config.max_lifetime_millis =
+	    ReadUBigIntOption(ctx, "mysql_pool_connection_max_lifetime_millis", config.max_lifetime_millis);
+	config.idle_timeout_millis =
+	    ReadUBigIntOption(ctx, "mysql_pool_connection_idle_timeout_millis", config.idle_timeout_millis);
+	config.start_reaper_thread = ReadBooleanOption(ctx, "mysql_pool_enable_reaper_thread", config.start_reaper_thread);
 
 	return config;
 }
 
-MySQLPooledConnection MySQLConnectionPool::Acquire(MySQLPoolAcquireMode acquire_mode, const std::string &time_zone) {
+MySQLPooledConnection MySQLConnectionPool::Acquire(dbconnector::pool::AcquireMode acquire_mode,
+                                                   const std::string &time_zone) {
 	MySQLPooledConnection pc;
 	switch (acquire_mode) {
-	case MySQLPoolAcquireMode::FORCE:
+	case dbconnector::pool::AcquireMode::FORCE:
 		pc = ForceAcquire();
 		break;
-	case MySQLPoolAcquireMode::WAIT:
+	case dbconnector::pool::AcquireMode::WAIT:
 		pc = WaitAcquire();
 		break;
-	case MySQLPoolAcquireMode::TRY:
+	case dbconnector::pool::AcquireMode::TRY:
 		pc = TryAcquire();
 		if (!pc) {
 			throw IOException("Connection pool exhausted: no connections available (try mode)");
@@ -229,21 +219,13 @@ MySQLPooledConnection MySQLConnectionPool::Acquire(MySQLPoolAcquireMode acquire_
 	return pc;
 }
 
-MySQLPoolAcquireMode MySQLConnectionPool::GetAcquireMode(ClientContext &context) {
+dbconnector::pool::AcquireMode MySQLConnectionPool::GetAcquireMode(ClientContext &context) {
 	Value mode_val;
 	if (context.TryGetCurrentSetting("mysql_pool_acquire_mode", mode_val)) {
 		auto mode_str = StringUtil::Lower(mode_val.ToString());
-		if (mode_str == "force") {
-			return MySQLPoolAcquireMode::FORCE;
-		} else if (mode_str == "wait") {
-			return MySQLPoolAcquireMode::WAIT;
-		} else if (mode_str == "try") {
-			return MySQLPoolAcquireMode::TRY;
-		} else {
-			throw IOException("Invalid unsupported acquire mode: '%s'", mode_str);
-		}
+		return dbconnector::pool::AcquireModeHelpers::FromString(mode_str);
 	}
-	return MySQLPoolAcquireMode::FORCE;
+	return dbconnector::pool::AcquireMode::FORCE;
 }
 
 } // namespace duckdb

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -150,6 +150,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	auto &db = loader.GetDatabaseInstance();
 
+	dbconnector::pool::ConnectionPoolConfig default_pool_config;
 	auto &config = DBConfig::GetConfig(db);
 	StorageExtension::Register(config, "mysql_scanner", make_shared_ptr<MySQLStorageExtension>());
 
@@ -176,33 +177,35 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Whether to run 'START TRANSACTION'/'COMMIT'/'ROLLBACK' on MySQL connections",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), MySQLClearCacheFunction::ClearCacheOnSetting);
 	config.AddExtensionOption(
-	    "mysql_pool_size", "Maximum number of connections per MySQL catalog (default: min(cpu_count, 8))",
-	    LogicalType::UBIGINT, Value::UBIGINT(MySQLConnectionPool::DefaultPoolSize()), ValidatePoolSize);
+	    "mysql_pool_size",
+	    "Maximum number of connections per MySQL catalog (default: min(cpu_count, 4 <= cpu_count * 1.5 <= 32))",
+	    LogicalType::UBIGINT, Value::UBIGINT(default_pool_config.max_connections), ValidatePoolSize);
 	config.AddExtensionOption("mysql_pool_wait_timeout_millis",
 	                          "Timeout in milliseconds when waiting for a connection from the pool (default: 30000)",
-	                          LogicalType::UBIGINT, Value::UBIGINT(30000));
+	                          LogicalType::UBIGINT, Value::UBIGINT(default_pool_config.wait_timeout_millis));
 	config.AddExtensionOption("mysql_pool_connection_max_lifetime_millis",
 	                          "Maximum age in milliseconds of a pooled connection since it was first opened. When "
 	                          "exceeded, the connection is closed instead of being returned to the cache (default: 0 - "
 	                          "disabled)",
-	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+	                          LogicalType::UBIGINT, Value::UBIGINT(default_pool_config.max_lifetime_millis));
 	config.AddExtensionOption("mysql_pool_connection_idle_timeout_millis",
 	                          "Maximum time in milliseconds a connection can sit idle in the cache before being closed "
-	                          "(default: 0 - disabled)",
-	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+	                          "(default: 60000 - disabled)",
+	                          LogicalType::UBIGINT, Value::UBIGINT(default_pool_config.idle_timeout_millis));
 	config.AddExtensionOption("mysql_pool_enable_reaper_thread",
 	                          "Whether to run a dedicated thread that periodically scans the pool and removes expired "
-	                          "connections (default: false)",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	                          "connections (default: true)",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(default_pool_config.start_reaper_thread));
 	config.AddExtensionOption(
 	    "mysql_pool_acquire_mode",
 	    "How to acquire connections from the pool: 'force' (always connect, ignore pool limit), "
 	    "'wait' (block until available), 'try' (fail immediately if unavailable) (default: force)",
-	    LogicalType::VARCHAR, Value("force"), ValidatePoolAcquireMode);
+	    LogicalType::VARCHAR, Value(dbconnector::pool::AcquireModeHelpers::ToString(default_pool_config.acquire_mode)),
+	    ValidatePoolAcquireMode);
 	config.AddExtensionOption(
 	    "mysql_pool_enable_thread_local_cache",
-	    "Enable thread-local connection caching for faster same-thread connection reuse (default: true)",
-	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	    "Enable thread-local connection caching for faster same-thread connection reuse (default: false)",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(default_pool_config.tl_cache_enabled));
 	config.AddExtensionOption("mysql_compression_aware_costs",
 	                          "Apply compression ratios when estimating transfer costs (default: true)",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(true));


### PR DESCRIPTION
This PR changes the default connection pool settings to the following values:

 - `mysql_pool_acquire_mode`: `force`
 - `mysql_pool_size`: `4 <= cpu_count * 1.5 <= 32`
 - `mysql_pool_wait_timeout_millis`: `30000`
 - `mysql_pool_enable_thread_local_cache`: `FALSE`
 - `mysql_pool_connection_max_lifetime_millis`: `0` (not enforced)
 - `mysql_pool_connection_idle_timeout_millis`: `60000`
 - `mysql_pool_enable_reaper_thread`: `TRUE`