### PR TITLE
Make pushdown impl generic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,11 @@ add_library(
   mysql_storage.cpp
   mysql_types.cpp
   mysql_utils.cpp)
+
+add_library(mysql_ext_dbconn OBJECT dbconn/query/query_writer.cpp
+                                    dbconn/table_scan/filter_pushdown.cpp)
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:mysql_ext_library>
+    $<TARGET_OBJECTS:mysql_ext_dbconn>
     PARENT_SCOPE)

--- a/src/dbconn/query/query_writer.cpp
+++ b/src/dbconn/query/query_writer.cpp
@@ -1,0 +1,66 @@
+#include "dbconn/query/query_writer.hpp"
+
+#include <cstdint>
+
+namespace dbconnector {
+namespace query {
+
+std::string QueryWriter::EscapeQuotes(const std::string &text, char quote) {
+	std::string result;
+	for (auto c : text) {
+		if (c == quote) {
+			result += "\\";
+			result += quote;
+		} else if (c == '\\') {
+			result += "\\\\";
+		} else {
+			result += c;
+		}
+	}
+	return result;
+}
+
+std::string QueryWriter::WriteQuoted(const std::string &text, char quote) {
+	// 1. Escapes all occurences of 'quote' by escaping them with a backslash
+	// 2. Adds quotes around the string
+	return std::string(1, quote) + EscapeQuotes(text, quote) + std::string(1, quote);
+}
+
+std::string QueryWriter::WriteIdentifier(const std::string &identifier, char identifier_quote) {
+	return WriteQuoted(identifier, identifier_quote);
+}
+
+std::string QueryWriter::WriteLiteral(const std::string &identifier) {
+	return QueryWriter::WriteQuoted(identifier, '\'');
+}
+
+std::string QueryWriter::EncodeBlob(const std::string &val) {
+	char const HEX_DIGITS[] = "0123456789ABCDEF";
+
+	std::string result = "x'";
+	for (size_t i = 0; i < val.size(); i++) {
+		uint8_t byte_val = static_cast<uint8_t>(val[i]);
+		result += HEX_DIGITS[(byte_val >> 4) & 0xf];
+		result += HEX_DIGITS[byte_val & 0xf];
+	}
+	result += "'";
+	return result;
+}
+
+std::string QueryWriter::WriteConstant(const duckdb::Value &val) {
+	if (val.type().IsNumeric() || val.type().id() == duckdb::LogicalTypeId::BOOLEAN) {
+		return val.ToSQLString();
+	}
+	if (val.type().id() == duckdb::LogicalTypeId::BLOB) {
+		return EncodeBlob(duckdb::StringValue::Get(val));
+	}
+	if (val.type().id() == duckdb::LogicalTypeId::TIMESTAMP_TZ) {
+		return val.DefaultCastAs(duckdb::LogicalType::TIMESTAMP)
+		    .DefaultCastAs(duckdb::LogicalType::VARCHAR)
+		    .ToSQLString();
+	}
+	return val.DefaultCastAs(duckdb::LogicalType::VARCHAR).ToSQLString();
+}
+
+} // namespace query
+} // namespace dbconnector

--- a/src/dbconn/table_scan/filter_pushdown.cpp
+++ b/src/dbconn/table_scan/filter_pushdown.cpp
@@ -1,0 +1,175 @@
+#include "dbconn/table_scan/filter_pushdown.hpp"
+
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/filter/table_filter_functions.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#include "dbconn/query/query_writer.hpp"
+
+#include "dbconn/table_scan/table_scan_exception.hpp"
+
+namespace dbconnector {
+namespace table_scan {
+
+bool FilterPushdown::IsDirectReference(const duckdb::Expression &expr) {
+	switch (expr.GetExpressionClass()) {
+	case duckdb::ExpressionClass::BOUND_REF:
+	case duckdb::ExpressionClass::BOUND_COLUMN_REF:
+		return true;
+	default:
+		return false;
+	}
+}
+
+std::string FilterPushdown::CreateExpression(const std::string &column_name,
+                                             const duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &filters,
+                                             const std::string &op) {
+	duckdb::vector<std::string> filter_entries;
+	for (auto &filter : filters) {
+		auto new_filter = TransformExpression(column_name, *filter);
+		if (new_filter.empty()) {
+			continue;
+		}
+		filter_entries.push_back(std::move(new_filter));
+	}
+	if (filter_entries.empty()) {
+		return std::string();
+	}
+	return "(" + duckdb::StringUtil::Join(filter_entries, " " + op + " ") + ")";
+}
+
+std::string FilterPushdown::TransformComparison(duckdb::ExpressionType type) {
+	switch (type) {
+	case duckdb::ExpressionType::COMPARE_EQUAL:
+		return "=";
+	case duckdb::ExpressionType::COMPARE_NOTEQUAL:
+		return "!=";
+	case duckdb::ExpressionType::COMPARE_LESSTHAN:
+		return "<";
+	case duckdb::ExpressionType::COMPARE_GREATERTHAN:
+		return ">";
+	case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return "<=";
+	case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return ">=";
+	default:
+		throw TableScanException("Unsupported expression type: '" + duckdb::EnumUtil::ToString(type) + "'");
+	}
+}
+
+std::string FilterPushdown::TransformExpression(const std::string &column_name, const duckdb::Expression &expr) {
+	if (duckdb::BoundComparisonExpression::IsComparison(expr)) {
+		auto &comparison = expr.Cast<duckdb::BoundFunctionExpression>();
+		auto comparison_type = comparison.GetExpressionType();
+		auto &left = duckdb::BoundComparisonExpression::Left(comparison);
+		auto &right = duckdb::BoundComparisonExpression::Right(comparison);
+		const duckdb::Value *constant = nullptr;
+		if (IsDirectReference(left) && right.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT) {
+			constant = &right.Cast<duckdb::BoundConstantExpression>().value;
+		} else if (left.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT && IsDirectReference(right)) {
+			constant = &left.Cast<duckdb::BoundConstantExpression>().value;
+			comparison_type = FlipComparisonExpression(comparison_type);
+		} else {
+			return std::string();
+		}
+		auto constant_string = query::QueryWriter::WriteConstant(*constant);
+		auto operator_string = TransformComparison(comparison_type);
+		return duckdb::StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
+	}
+
+	switch (expr.GetExpressionClass()) {
+	case duckdb::ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conjunction = expr.Cast<duckdb::BoundConjunctionExpression>();
+		switch (conjunction.GetExpressionType()) {
+		case duckdb::ExpressionType::CONJUNCTION_AND:
+			return CreateExpression(column_name, conjunction.children, "AND");
+		case duckdb::ExpressionType::CONJUNCTION_OR:
+			return CreateExpression(column_name, conjunction.children, "OR");
+		default:
+			return std::string();
+		}
+	}
+	case duckdb::ExpressionClass::BOUND_OPERATOR: {
+		auto &op = expr.Cast<duckdb::BoundOperatorExpression>();
+		switch (op.GetExpressionType()) {
+		case duckdb::ExpressionType::OPERATOR_IS_NULL:
+			if (op.children.size() == 1 && IsDirectReference(*op.children[0])) {
+				return column_name + " IS NULL";
+			}
+			return std::string();
+		case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL:
+			if (op.children.size() == 1 && IsDirectReference(*op.children[0])) {
+				return column_name + " IS NOT NULL";
+			}
+			return std::string();
+		case duckdb::ExpressionType::COMPARE_IN: {
+			if (op.children.empty() || !IsDirectReference(*op.children[0])) {
+				return std::string();
+			}
+			std::string in_list;
+			for (idx_t i = 1; i < op.children.size(); i++) {
+				if (op.children[i]->GetExpressionClass() != duckdb::ExpressionClass::BOUND_CONSTANT) {
+					return std::string();
+				}
+				if (!in_list.empty()) {
+					in_list += ", ";
+				}
+				in_list +=
+				    query::QueryWriter::WriteConstant(op.children[i]->Cast<duckdb::BoundConstantExpression>().value);
+			}
+			return column_name + " IN (" + in_list + ")";
+		}
+		default:
+			return std::string();
+		}
+	}
+	case duckdb::ExpressionClass::BOUND_FUNCTION: {
+		auto &func = expr.Cast<duckdb::BoundFunctionExpression>();
+		if (func.function.GetName() == duckdb::OptionalFilterScalarFun::NAME && func.bind_info) {
+			auto &data = func.bind_info->Cast<duckdb::OptionalFilterFunctionData>();
+			return data.child_filter_expr ? TransformExpression(column_name, *data.child_filter_expr) : std::string();
+		}
+		if (func.function.GetName() == duckdb::SelectivityOptionalFilterScalarFun::NAME && func.bind_info) {
+			auto &data = func.bind_info->Cast<duckdb::SelectivityOptionalFilterFunctionData>();
+			return data.child_filter_expr ? TransformExpression(column_name, *data.child_filter_expr) : std::string();
+		}
+		if (func.function.GetName() == duckdb::DynamicFilterScalarFun::NAME) {
+			return std::string();
+		}
+		return std::string();
+	}
+	default:
+		return std::string();
+	}
+}
+
+std::string FilterPushdown::TransformFilter(const FilterPushdownConfig &config, const std::string &column_name,
+                                            const duckdb::TableFilter &filter) {
+	std::string column_name_quoted = query::QueryWriter::WriteIdentifier(column_name, config.identifier_quote);
+	auto &expr = GetExpression(filter, "FilterPushdown::TransformFilter");
+	return TransformExpression(column_name_quoted, expr);
+}
+
+bool FilterPushdown::IsInternalFilter(const duckdb::TableFilter &filter) {
+	auto &expr = GetExpression(filter, "FilterPushdown::IsInternalFilter");
+	return expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_FUNCTION &&
+	       expr.ToString().find("__internal_tablefilter_") == 0;
+}
+
+std::string FilterPushdown::ToString(const duckdb::TableFilter &filter) {
+	auto &expr = GetExpression(filter, "FilterPushdown::ToString");
+	return expr.ToString();
+}
+
+const duckdb::Expression &FilterPushdown::GetExpression(const duckdb::TableFilter &filter, const std::string &context) {
+	auto &expr_filter = duckdb::ExpressionFilter::GetExpressionFilter(filter, context.c_str());
+	return *expr_filter.expr;
+}
+
+} // namespace table_scan
+} // namespace dbconnector

--- a/src/include/dbconn/query/query_writer.hpp
+++ b/src/include/dbconn/query/query_writer.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+#include "duckdb/common/types/value.hpp"
+
+namespace dbconnector {
+namespace query {
+
+class QueryWriter {
+
+public:
+	static std::string WriteIdentifier(const std::string &identifier, char identifier_quote);
+	static std::string WriteLiteral(const std::string &identifier);
+	static std::string WriteConstant(const duckdb::Value &val);
+
+private:
+	static std::string EncodeBlob(const std::string &val);
+	static std::string EscapeQuotes(const std::string &text, char quote);
+	static std::string WriteQuoted(const std::string &text, char quote);
+};
+
+} // namespace query
+} // namespace dbconnector

--- a/src/include/dbconn/table_scan/filter_pushdown.hpp
+++ b/src/include/dbconn/table_scan/filter_pushdown.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/planner/table_filter.hpp"
+
+#include "filter_pushdown_config.hpp"
+
+namespace dbconnector {
+namespace table_scan {
+
+class FilterPushdown {
+
+public:
+	static std::string TransformFilter(const FilterPushdownConfig &config, const std::string &column_name,
+	                                   const duckdb::TableFilter &filter);
+
+	static bool IsInternalFilter(const duckdb::TableFilter &filter);
+	static std::string ToString(const duckdb::TableFilter &filter);
+
+private:
+	static std::string TransformExpression(const std::string &column_name, const duckdb::Expression &expr);
+	static std::string TransformComparison(duckdb::ExpressionType type);
+	static std::string CreateExpression(const std::string &column_name,
+	                                    const duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &filters,
+	                                    const std::string &op);
+	static bool IsDirectReference(const duckdb::Expression &expr);
+	static const duckdb::Expression &GetExpression(const duckdb::TableFilter &filter, const std::string &context);
+};
+
+} // namespace table_scan
+} // namespace dbconnector

--- a/src/include/dbconn/table_scan/filter_pushdown_config.hpp
+++ b/src/include/dbconn/table_scan/filter_pushdown_config.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace dbconnector {
+namespace table_scan {
+
+struct FilterPushdownConfig {
+	char identifier_quote;
+
+	explicit FilterPushdownConfig(char identifier_quote_p) : identifier_quote(identifier_quote_p) {
+	}
+};
+
+} // namespace table_scan
+} // namespace dbconnector

--- a/src/include/dbconn/table_scan/table_scan_exception.hpp
+++ b/src/include/dbconn/table_scan/table_scan_exception.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace dbconnector {
+namespace table_scan {
+
+class TableScanException : public std::exception {
+protected:
+	std::string message;
+
+public:
+	TableScanException() = default;
+
+	TableScanException(const std::string &message) : message(message.data(), message.length()) {
+	}
+
+	virtual const char *what() const noexcept {
+		return message.c_str();
+	}
+};
+
+} // namespace table_scan
+} // namespace dbconnector

--- a/src/include/mysql_filter_pushdown.hpp
+++ b/src/include/mysql_filter_pushdown.hpp
@@ -17,14 +17,6 @@ class MySQLFilterPushdown {
 public:
 	static string TransformFilters(const vector<column_t> &column_ids, optional_ptr<TableFilterSet> filters,
 	                               const vector<string> &names);
-
-	static string TransformFilter(const string &column_name, const TableFilter &filter);
-
-private:
-	static string TransformExpression(const string &column_name, const Expression &expr);
-	static string TransformComparison(ExpressionType type);
-	static string CreateExpression(const string &column_name, const vector<unique_ptr<Expression>> &filters,
-	                               const string &op);
 };
 
 } // namespace duckdb

--- a/src/mysql_filter_pushdown.cpp
+++ b/src/mysql_filter_pushdown.cpp
@@ -1,156 +1,8 @@
 #include "mysql_filter_pushdown.hpp"
-#include "mysql_utils.hpp"
-#include "duckdb/planner/expression/bound_comparison_expression.hpp"
-#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/planner/expression/bound_operator_expression.hpp"
-#include "duckdb/planner/filter/table_filter_functions.hpp"
+
+#include "dbconn/table_scan/filter_pushdown.hpp"
 
 namespace duckdb {
-
-static bool IsDirectReference(const Expression &expr) {
-	switch (expr.GetExpressionClass()) {
-	case ExpressionClass::BOUND_REF:
-	case ExpressionClass::BOUND_COLUMN_REF:
-		return true;
-	default:
-		return false;
-	}
-}
-
-string MySQLFilterPushdown::CreateExpression(const string &column_name, const vector<unique_ptr<Expression>> &filters,
-                                             const string &op) {
-	vector<string> filter_entries;
-	for (auto &filter : filters) {
-		auto new_filter = TransformExpression(column_name, *filter);
-		if (new_filter.empty()) {
-			continue;
-		}
-		filter_entries.push_back(std::move(new_filter));
-	}
-	if (filter_entries.empty()) {
-		return string();
-	}
-	return "(" + StringUtil::Join(filter_entries, " " + op + " ") + ")";
-}
-
-string MySQLFilterPushdown::TransformComparison(ExpressionType type) {
-	switch (type) {
-	case ExpressionType::COMPARE_EQUAL:
-		return "=";
-	case ExpressionType::COMPARE_NOTEQUAL:
-		return "!=";
-	case ExpressionType::COMPARE_LESSTHAN:
-		return "<";
-	case ExpressionType::COMPARE_GREATERTHAN:
-		return ">";
-	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-		return "<=";
-	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-		return ">=";
-	default:
-		throw NotImplementedException("Unsupported expression type");
-	}
-}
-
-string MySQLFilterPushdown::TransformExpression(const string &column_name, const Expression &expr) {
-	if (BoundComparisonExpression::IsComparison(expr)) {
-		auto &comparison = expr.Cast<BoundFunctionExpression>();
-		auto comparison_type = comparison.GetExpressionType();
-		auto &left = BoundComparisonExpression::Left(comparison);
-		auto &right = BoundComparisonExpression::Right(comparison);
-		const Value *constant = nullptr;
-		if (IsDirectReference(left) && right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-			constant = &right.Cast<BoundConstantExpression>().value;
-		} else if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT && IsDirectReference(right)) {
-			constant = &left.Cast<BoundConstantExpression>().value;
-			comparison_type = FlipComparisonExpression(comparison_type);
-		} else {
-			return string();
-		}
-		auto constant_string = MySQLUtils::TransformConstant(*constant);
-		auto operator_string = TransformComparison(comparison_type);
-		return StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
-	}
-
-	switch (expr.GetExpressionClass()) {
-	case ExpressionClass::BOUND_CONJUNCTION: {
-		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
-		switch (conjunction.GetExpressionType()) {
-		case ExpressionType::CONJUNCTION_AND:
-			return CreateExpression(column_name, conjunction.children, "AND");
-		case ExpressionType::CONJUNCTION_OR:
-			return CreateExpression(column_name, conjunction.children, "OR");
-		default:
-			return string();
-		}
-	}
-	case ExpressionClass::BOUND_OPERATOR: {
-		auto &op = expr.Cast<BoundOperatorExpression>();
-		switch (op.GetExpressionType()) {
-		case ExpressionType::OPERATOR_IS_NULL:
-			if (op.children.size() == 1 && IsDirectReference(*op.children[0])) {
-				return column_name + " IS NULL";
-			}
-			return string();
-		case ExpressionType::OPERATOR_IS_NOT_NULL:
-			if (op.children.size() == 1 && IsDirectReference(*op.children[0])) {
-				return column_name + " IS NOT NULL";
-			}
-			return string();
-		case ExpressionType::COMPARE_IN: {
-			if (op.children.empty() || !IsDirectReference(*op.children[0])) {
-				return string();
-			}
-			string in_list;
-			for (idx_t i = 1; i < op.children.size(); i++) {
-				if (op.children[i]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
-					return string();
-				}
-				if (!in_list.empty()) {
-					in_list += ", ";
-				}
-				in_list += MySQLUtils::TransformConstant(op.children[i]->Cast<BoundConstantExpression>().value);
-			}
-			return column_name + " IN (" + in_list + ")";
-		}
-		default:
-			return string();
-		}
-	}
-	case ExpressionClass::BOUND_FUNCTION: {
-		auto &func = expr.Cast<BoundFunctionExpression>();
-		if (func.function.GetName() == OptionalFilterScalarFun::NAME && func.bind_info) {
-			auto &data = func.bind_info->Cast<OptionalFilterFunctionData>();
-			return data.child_filter_expr ? TransformExpression(column_name, *data.child_filter_expr) : string();
-		}
-		if (func.function.GetName() == SelectivityOptionalFilterScalarFun::NAME && func.bind_info) {
-			auto &data = func.bind_info->Cast<SelectivityOptionalFilterFunctionData>();
-			return data.child_filter_expr ? TransformExpression(column_name, *data.child_filter_expr) : string();
-		}
-		if (func.function.GetName() == DynamicFilterScalarFun::NAME) {
-			return string();
-		}
-		return string();
-	}
-	default:
-		return string();
-	}
-}
-
-string MySQLFilterPushdown::TransformFilter(const string &column_name, const TableFilter &filter) {
-	auto &expr_filter = ExpressionFilter::GetExpressionFilter(filter, "MySQLFilterPushdown::TransformFilter");
-	auto &expr = *expr_filter.expr;
-	string filter_string = TransformExpression(column_name, expr);
-	if (filter_string.empty() && expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
-		throw NotImplementedException(
-		    "Unsupported filter pushdown, use 'mysql_enable_filter_pushdown=FALSE' to disable pushdowns."
-		    " Problematic filter: \"%s\"",
-		    expr.ToString());
-	}
-	return filter_string;
-}
 
 string MySQLFilterPushdown::TransformFilters(const vector<column_t> &column_ids, optional_ptr<TableFilterSet> filters,
                                              const vector<string> &names) {
@@ -160,9 +12,20 @@ string MySQLFilterPushdown::TransformFilters(const vector<column_t> &column_ids,
 	}
 	string result;
 	for (auto &entry : *filters) {
-		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.GetIndex()]]);
+		column_t col_id = column_ids[entry.GetIndex()];
+		auto column_name = names[col_id];
 		auto &filter = entry.Filter();
-		auto new_filter = TransformFilter(column_name, filter);
+		dbconnector::table_scan::FilterPushdownConfig config('`');
+		auto new_filter = dbconnector::table_scan::FilterPushdown::TransformFilter(config, column_name, filter);
+		if (new_filter.empty()) {
+			if (dbconnector::table_scan::FilterPushdown::IsInternalFilter(filter)) {
+				continue;
+			}
+			throw NotImplementedException(
+			    "Unsupported filter pushdown, use 'mysql_enable_filter_pushdown=FALSE' to disable pushdowns."
+			    " Problematic filter: \"%s\"",
+			    dbconnector::table_scan::FilterPushdown::ToString(filter));
+		}
 		if (!result.empty()) {
 			result += " AND ";
 		}

--- a/src/storage/mysql_optimizer.cpp
+++ b/src/storage/mysql_optimizer.cpp
@@ -14,6 +14,8 @@
 #include "mysql_scanner.hpp"
 #include "storage/federation/cost_model.hpp"
 
+#include "dbconn/table_scan/filter_pushdown.hpp"
+
 namespace duckdb {
 
 struct MySQLOperators {
@@ -352,8 +354,10 @@ static PushedAggregate TryPushAggregateToMySQL(LogicalAggregate &aggr, LogicalOp
 			if (table_col_idx >= get.names.size()) {
 				return res;
 			}
-			auto column_name = MySQLUtils::WriteIdentifier(get.names[table_col_idx]);
-			auto new_filter = MySQLFilterPushdown::TransformFilter(column_name, entry.Filter());
+			auto column_name = get.names[table_col_idx];
+			dbconnector::table_scan::FilterPushdownConfig config('`');
+			auto new_filter =
+			    dbconnector::table_scan::FilterPushdown::TransformFilter(config, column_name, entry.Filter());
 			if (new_filter.empty()) {
 				return res;
 			}

--- a/src/storage/mysql_predicate_analyzer.cpp
+++ b/src/storage/mysql_predicate_analyzer.cpp
@@ -1,5 +1,4 @@
 #include "storage/mysql_predicate_analyzer.hpp"
-#include "mysql_filter_pushdown.hpp"
 #include "mysql_utils.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
@@ -7,6 +6,8 @@
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/table_filter_set.hpp"
+
+#include "dbconn/table_scan/filter_pushdown.hpp"
 
 #include <cmath>
 #include <unordered_set>
@@ -149,7 +150,8 @@ PredicateAnalysis PredicateAnalyzer::AnalyzeFilter(const string &column_name, co
 	PredicateAnalysis result;
 	result.column_name = column_name;
 
-	result.mysql_predicate = MySQLFilterPushdown::TransformFilter(column_name, filter);
+	dbconnector::table_scan::FilterPushdownConfig config('`');
+	result.mysql_predicate = dbconnector::table_scan::FilterPushdown::TransformFilter(config, column_name, filter);
 	if (result.mysql_predicate.empty()) {
 		result.decision = PushdownDecision::EXECUTE_IN_DUCKDB;
 		result.estimated_selectivity = DEFAULT_SELECTIVITY;


### PR DESCRIPTION
This PR externalizes the filter pushdown code so it can be used from both MySQL and Postgres extensions. It is currently placed under `src/dbconn`, going to be moved to [database-connector](https://github.com/duckdb/database-connector).