### PR TITLE
Remove adaptive streaming support

### DIFF
--- a/src/include/mysql_scanner.hpp
+++ b/src/include/mysql_scanner.hpp
@@ -34,7 +34,6 @@ struct MySQLBindData : public FunctionData {
 	string group_by_clause;
 	string aggregate_where_clause;
 	bool has_aggregate_pushdown = false;
-	MySQLResultStreaming streaming = MySQLResultStreaming::UNINITIALIZED;
 
 	bool use_predicate_analyzer = false;
 

--- a/src/include/storage/mysql_catalog.hpp
+++ b/src/include/storage/mysql_catalog.hpp
@@ -64,7 +64,6 @@ public:
 
 	void ClearCache();
 
-	static void MaterializeMySQLScans(PhysicalOperator &op);
 	static bool IsMySQLScan(const string &name);
 	static bool IsMySQLQuery(const string &name);
 

--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -481,19 +481,6 @@ bool MySQLCatalog::IsMySQLQuery(const string &name) {
 	return name == "mysql_query";
 }
 
-void MySQLCatalog::MaterializeMySQLScans(PhysicalOperator &op) {
-	if (op.type == PhysicalOperatorType::TABLE_SCAN) {
-		auto &table_scan = op.Cast<PhysicalTableScan>();
-		if (MySQLCatalog::IsMySQLScan(table_scan.function.name)) {
-			auto &bind_data = table_scan.bind_data->Cast<MySQLBindData>();
-			bind_data.streaming = MySQLResultStreaming::FORCE_MATERIALIZATION;
-		}
-	}
-	for (auto &child : op.children) {
-		MaterializeMySQLScans(child);
-	}
-}
-
 DatabaseSize MySQLCatalog::GetDatabaseSize(ClientContext &context) {
 	if (default_schema.empty()) {
 		throw InvalidInputException("Attempting to fetch the database size - but no database was provided "

--- a/src/storage/mysql_execute_query.cpp
+++ b/src/storage/mysql_execute_query.cpp
@@ -162,7 +162,6 @@ PhysicalOperator &MySQLCatalog::PlanDelete(ClientContext &context, PhysicalPlanG
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion of a MySQL table");
 	}
-	MySQLCatalog::MaterializeMySQLScans(plan);
 
 	auto &execute = planner.Make<MySQLExecuteQuery>(op, "DELETE", op.table, ConstructDeleteStatement(op, plan));
 	execute.children.push_back(plan);
@@ -218,7 +217,6 @@ PhysicalOperator &MySQLCatalog::PlanUpdate(ClientContext &context, PhysicalPlanG
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for updates of a MySQL table");
 	}
-	MySQLCatalog::MaterializeMySQLScans(plan);
 
 	auto &execute = planner.Make<MySQLExecuteQuery>(op, "UPDATE", op.table, ConstructUpdateStatement(op, plan));
 	execute.children.push_back(plan);

--- a/src/storage/mysql_insert.cpp
+++ b/src/storage/mysql_insert.cpp
@@ -321,7 +321,6 @@ PhysicalOperator &MySQLCatalog::PlanInsert(ClientContext &context, PhysicalPlanG
 	if (op.on_conflict_info.action_type != OnConflictAction::THROW) {
 		throw BinderException("ON CONFLICT clause not yet supported for insertion into MySQL table");
 	}
-	MySQLCatalog::MaterializeMySQLScans(*plan);
 
 	D_ASSERT(plan);
 	auto &inner_plan = AddCastToMySQLTypes(context, planner, *plan);
@@ -332,7 +331,6 @@ PhysicalOperator &MySQLCatalog::PlanInsert(ClientContext &context, PhysicalPlanG
 
 PhysicalOperator &MySQLCatalog::PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner,
                                                   LogicalCreateTable &op, PhysicalOperator &plan) {
-	MySQLCatalog::MaterializeMySQLScans(plan);
 	auto &inner_plan = AddCastToMySQLTypes(context, planner, plan);
 	auto &insert = planner.Make<MySQLInsert>(op, op.schema, std::move(op.info));
 	insert.children.push_back(inner_plan);

--- a/src/storage/mysql_optimizer.cpp
+++ b/src/storage/mysql_optimizer.cpp
@@ -22,26 +22,6 @@ struct MySQLOperators {
 	reference_map_t<MySQLCatalog, vector<reference<LogicalGet>>> scans;
 };
 
-void GatherMySQLScans(LogicalOperator &op, MySQLOperators &result) {
-	if (op.type == LogicalOperatorType::LOGICAL_GET) {
-		auto &get = op.Cast<LogicalGet>();
-		auto &table_scan = get.function;
-		if (MySQLCatalog::IsMySQLScan(table_scan.name)) {
-			auto &bind_data = get.bind_data->Cast<MySQLBindData>();
-			auto &catalog = bind_data.table.ParentCatalog().Cast<MySQLCatalog>();
-			result.scans[catalog].push_back(get);
-		}
-		if (MySQLCatalog::IsMySQLQuery(table_scan.name)) {
-			auto &bind_data = get.bind_data->Cast<MySQLQueryBindData>();
-			auto &catalog = bind_data.catalog.Cast<MySQLCatalog>();
-			result.scans[catalog].push_back(get);
-		}
-	}
-	for (auto &child : op.children) {
-		GatherMySQLScans(*child, result);
-	}
-}
-
 static bool TraceColumnToGet(Expression &expr, LogicalOperator &child, LogicalGet &get, MySQLBindData &bind_data,
                              string &out) {
 	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
@@ -801,25 +781,6 @@ void OptimizeOrderByAndLimit(ClientContext &context, unique_ptr<LogicalOperator>
 }
 
 void MySQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
-	MySQLOperators operators;
-	GatherMySQLScans(*plan, operators);
-	for (auto &entry : operators.scans) {
-		MySQLResultStreaming result_streaming = MySQLResultStreaming::FORCE_MATERIALIZATION;
-		if (entry.second.size() == 1) {
-			result_streaming = MySQLResultStreaming::ALLOW_STREAMING;
-		}
-		for (auto &logical_get : entry.second) {
-			auto &get = logical_get.get();
-			if (MySQLCatalog::IsMySQLScan(get.function.name)) {
-				auto &bind_data = get.bind_data->Cast<MySQLBindData>();
-				if (bind_data.streaming == MySQLResultStreaming::UNINITIALIZED ||
-				    result_streaming == MySQLResultStreaming::FORCE_MATERIALIZATION) {
-					bind_data.streaming = result_streaming;
-				}
-			}
-		}
-	}
-
 	vector<AggregateRewriteInfo> rewrites;
 	OptimizeAggregates(input.context, plan, rewrites);
 	for (auto &info : rewrites) {


### PR DESCRIPTION
This PR is effectively undoing the improvements implemented in #131.

It appeared that detecting a single scan in a plan and enabling the streaming for it, while can benefit simple `FROM mysql_table` queries, causes [a number of problems in practice](https://github.com/duckdb/duckdb-mysql/pull/217#issuecomment-4130133502).

It is intended to rework the streaming for table scans using additional connections on top of the connection pool.

Right now (table scan streaming was already disabled in 1.5.2 with #217) the only option to stream results is to use `mysql_query()` function that has `stream_results` named parameter that is enabled by default. It opens a dedicated connection for this scan at bind time and keeps this connection open until the query is over.

See also: #222