### PR TITLE
Prevent double init of a transaction-bound cxn

### DIFF
--- a/src/include/storage/mysql_transaction.hpp
+++ b/src/include/storage/mysql_transaction.hpp
@@ -39,6 +39,7 @@ private:
 
 	MySQLCatalog &catalog;
 	MySQLPooledConnection pooled_connection;
+	mutex pooled_connection_lock;
 	bool transactions_enabled = true;
 	MySQLTransactionState transaction_state = MySQLTransactionState::TRANSACTION_NOT_YET_STARTED;
 	AccessMode access_mode;

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -58,6 +58,8 @@ void MySQLTransaction::Rollback() {
 }
 
 void MySQLTransaction::EnsureConnection() {
+	lock_guard<mutex> guard(pooled_connection_lock);
+
 	if (pooled_connection) {
 		return;
 	}

--- a/test/sql/multi_scan_aggregate.test
+++ b/test/sql/multi_scan_aggregate.test
@@ -1,0 +1,57 @@
+# name: test/sql/multi_scan_aggregate.test
+# description: Test multiple simultaneous scans that are aggregaed on DuckDB side
+# group: [sql]
+
+# see https://github.com/duckdb/duckdb-mysql/issues/225
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS simple (TYPE MYSQL_SCANNER)
+
+statement ok
+CREATE OR REPLACE TABLE simple.aggr_union_test_a AS
+SELECT '2020-01-01' insert_date, unnest(range(1<<14)) amount
+
+statement ok
+CREATE OR REPLACE TABLE simple.aggr_union_test_b AS
+SELECT '2021-01-01' insert_date, unnest(range(1<<14)) amount
+
+# Note, 'date()' is necessary to prevent aggregate pushdown
+
+query II
+SELECT date(t.insert_date) AS d, sum(t.amount) AS s
+FROM simple.aggr_union_test_a t
+GROUP BY 1
+----
+2020-01-01	134209536
+
+query II
+SELECT date(t.insert_date) AS d, sum(t.amount) AS s
+FROM simple.aggr_union_test_b t
+GROUP BY 1
+----
+2021-01-01	134209536
+
+query II
+SELECT date(t.insert_date) AS d, sum(t.amount) AS s
+FROM simple.aggr_union_test_a t
+GROUP BY 1
+UNION ALL
+SELECT date(t.insert_date) AS d, sum(t.amount) AS s
+FROM simple.aggr_union_test_b t
+GROUP BY 1   
+----
+2020-01-01	134209536
+2021-01-01	134209536
+
+statement ok
+DROP TABLE simple.aggr_union_test_a
+
+statement ok
+DROP TABLE simple.aggr_union_test_b
+
+statement ok
+DETACH simple;


### PR DESCRIPTION
When a query is run over multiple tables in the attached MySQL database, such query is transformed into multiple MySQL queries - one per tables.

Table scans (over MySQL tables) themselves are not parallel (unlike the Postgres extension), but multiple scans over different tables can run in parallel.

To keep the consistency guarantees, all scans are run in a single MySQL transaction. Thus all scans use the same MySQL connection that is bound to that transaction. This connection is taken from a connection pool on demand, when the first query is run. Initialization of this connection was not synchronized, so when 2 scans are run simultaneously it could have been initialized multiple times, making the scans to run on different connections.

When a connection is re-assigned on a duplicate init, the old connection is [returned to the pool](https://github.com/duckdb/database-connector/blob/7777dac887a48769684900a627ecaaf6feb3f4c5/src/include/dbconnector/pool/pooled_connection_impl.hpp#L41-L52). Before returning it to the pool, `mysql_reset_connection` is called on thi connection. This causes the [invalidation of all statements](https://github.com/mariadb-corporation/mariadb-connector-c/blob/e868ec9bf1c2fc4d74cd61597d4cf3f0b3249082/libmariadb/mariadb_lib.c#L4950) that were opened on that connections. Thus, despite the result set for the first scan is cached in memory, it needs to be accessed with `mysql_stmt_fetch`. This fetch does not do any IO on the connection, but still requires the statement to have the valid parent connection, that is no longer the case after `mysql_reset_connection` was called on that connection. At this point the crash happens.

This PR fixes the problem by synchronizing the connection initialization .

In general, more caution needs to be applied on code paths where `libmariadb` API is used concurrently from multiple threads on the same connection. Fixes in that area are going to be added in follow-up PRs.

Testing: a test case is added, that uses suffuciently large result for the first scan and an unpushable aggregate (so the result is read by DuckDB promply) and was causing the crash in 50+% of runs.

Fixes: #225