### PR TITLE
Use more locking around libmariadb

### DIFF
--- a/src/include/mysql_connection.hpp
+++ b/src/include/mysql_connection.hpp
@@ -76,17 +76,6 @@ public:
 	bool IsOpen();
 	void Close();
 
-	shared_ptr<OwnedMySQLConnection> GetConnection() {
-		return connection;
-	}
-
-	MYSQL *GetConn() {
-		if (!connection || !connection->connection) {
-			throw InternalException("MySQLConnection::GetConn - no connection available");
-		}
-		return connection->connection;
-	}
-
 	static void DebugSetPrintQueries(bool print);
 	static bool DebugPrintQueries();
 
@@ -94,11 +83,21 @@ public:
 		type_config = std::move(new_config);
 	}
 
+	bool IsConnectionHealthy();
+	void Reset();
+
 private:
 	unique_ptr<MySQLResult> QueryInternal(const string &query, const vector<Value> &params,
 	                                      MySQLResultStreaming streaming, MySQLConnectorInterface con_interface);
 	idx_t MySQLExecute(MYSQL_STMT *stmt, const string &query, const vector<Value> &params, bool streaming,
 	                   bool prepared = false);
+
+	MYSQL *GetConn() {
+		if (!connection || !connection->connection) {
+			throw InternalException("MySQLConnection::GetConn - no connection available");
+		}
+		return connection->connection;
+	}
 
 	mutex query_lock;
 	shared_ptr<OwnedMySQLConnection> connection;

--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -25,9 +25,10 @@ inline void MySQLResultDelete(MYSQL_RES *res) {
 
 class MySQLResult {
 public:
-	MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, MySQLTypeConfig type_config_p,
-	            const string &connection_string_p, unsigned long connection_id_p, MySQLResultStreaming streaming_p,
-	            idx_t affected_rows_p, vector<MySQLField> fields_p = vector<MySQLField>());
+	MySQLResult(mutex &query_lock_p, const std::string &query_p, MySQLStatementPtr stmt_p,
+	            MySQLTypeConfig type_config_p, const string &connection_string_p, unsigned long connection_id_p,
+	            MySQLResultStreaming streaming_p, idx_t affected_rows_p,
+	            vector<MySQLField> fields_p = vector<MySQLField>());
 
 	~MySQLResult();
 
@@ -43,6 +44,7 @@ public:
 	const vector<MySQLField> &Fields();
 
 private:
+	mutex &query_lock;
 	string query;
 	MySQLStatementPtr stmt;
 	MySQLTypeConfig type_config;

--- a/src/mysql_connection.cpp
+++ b/src/mysql_connection.cpp
@@ -47,7 +47,7 @@ idx_t MySQLConnection::MySQLExecute(MYSQL_STMT *stmt, const string &query, const
 		Printer::Print(query + "\n");
 	}
 
-	lock_guard<mutex> l(query_lock);
+	lock_guard<mutex> guard(query_lock);
 
 	if (!stmt) { // basic interface
 		auto con = GetConn();
@@ -127,14 +127,19 @@ unique_ptr<MySQLResult> MySQLConnection::QueryInternal(const string &query, cons
 		return unique_ptr<MySQLResult>(nullptr);
 	}
 
-	auto stmt = MySQLStatementPtr(mysql_stmt_init(con), MySQLStatementDelete);
-	if (!stmt) {
-		throw IOException("Failed to initialize MySQL query \"%s\": %s\n", query.c_str(), mysql_error(con));
+	auto stmt = MySQLStatementPtr(nullptr, MySQLStatementDelete);
+	{
+		lock_guard<mutex> l(query_lock);
+		stmt = MySQLStatementPtr(mysql_stmt_init(con), MySQLStatementDelete);
+		if (!stmt) {
+			throw IOException("Failed to initialize MySQL query \"%s\": %s\n", query.c_str(), mysql_error(con));
+		}
 	}
+
 	idx_t affected_rows = MySQLExecute(stmt.get(), query, params, result_streaming);
 	unsigned long connection_id = connection->GetID();
-	return make_uniq<MySQLResult>(query, std::move(stmt), type_config, connection_string, connection_id, streaming,
-	                              affected_rows);
+	return make_uniq<MySQLResult>(query_lock, query, std::move(stmt), type_config, connection_string, connection_id,
+	                              streaming, affected_rows);
 }
 
 unique_ptr<MySQLResult> MySQLConnection::Query(const string &query, MySQLResultStreaming streaming) {
@@ -154,11 +159,12 @@ unique_ptr<MySQLResult> MySQLConnection::Query(MySQLStatement &stmt, const vecto
 	idx_t affected_rows = MySQLExecute(stmt.get(), stmt.Query(), params, result_streaming, prepared);
 	auto stmt_ptr = stmt.release();
 	unsigned long connection_id = connection->GetID();
-	return make_uniq<MySQLResult>(stmt.Query(), std::move(stmt_ptr), type_config, connection_string, connection_id,
-	                              streaming, affected_rows, stmt.FieldsCopy());
+	return make_uniq<MySQLResult>(query_lock, stmt.Query(), std::move(stmt_ptr), type_config, connection_string,
+	                              connection_id, streaming, affected_rows, stmt.FieldsCopy());
 }
 
 unique_ptr<MySQLStatement> MySQLConnection::Prepare(const string &query) {
+	lock_guard<mutex> l(query_lock);
 	auto con = GetConn();
 
 	auto stmt = MySQLStatementPtr(mysql_stmt_init(con), MySQLStatementDelete);
@@ -190,7 +196,7 @@ void MySQLConnection::Execute(const string &query, const vector<Value> &params) 
 }
 
 bool MySQLConnection::IsOpen() {
-	return connection.get();
+	return connection.get() != nullptr;
 }
 
 void MySQLConnection::Close() {
@@ -210,6 +216,51 @@ void MySQLConnection::DebugSetPrintQueries(bool print) {
 
 bool MySQLConnection::DebugPrintQueries() {
 	return debug_mysql_print_queries;
+}
+
+bool MySQLConnection::IsConnectionHealthy() {
+	if (!IsOpen()) {
+		return false;
+	}
+
+	lock_guard<mutex> guard(query_lock);
+
+	MYSQL *mysql_conn = GetConn();
+	if (mysql_ping(mysql_conn) != 0) {
+		unsigned int err = mysql_errno(mysql_conn);
+		(void)err;
+		return false;
+	}
+	return true;
+}
+
+void MySQLConnection::Reset() {
+	lock_guard<mutex> guard(query_lock);
+
+	MYSQL *mysql_conn = GetConn();
+
+#if defined(MARIADB_VERSION_ID) || (defined(MYSQL_VERSION_ID) && MYSQL_VERSION_ID >= 50703)
+	if (mysql_reset_connection(mysql_conn) != 0) {
+		throw IOException("Failed to reset MySQL connection: %s", mysql_error(mysql_conn));
+	}
+#else
+	if (mysql_change_user(mysql_conn, nullptr, nullptr, nullptr) != 0) {
+		throw IOException("Failed to reset MySQL connection: %s", mysql_error(mysql_conn));
+	}
+#endif
+
+	if (mysql_query(mysql_conn, "SET autocommit=1") != 0) {
+		throw IOException("Failed to set autocommit after connection reset: %s", mysql_error(mysql_conn));
+	}
+
+	if (mysql_set_character_set(mysql_conn, "utf8mb4") != 0) {
+		throw IOException("Failed to set character set after connection reset: %s", mysql_error(mysql_conn));
+	}
+
+	const char *charset = mysql_character_set_name(mysql_conn);
+	if (strcmp(charset, "utf8mb4") != 0) {
+		throw IOException("Character set verification failed: expected utf8mb4, got %s", charset);
+	}
 }
 
 } // namespace duckdb

--- a/src/mysql_connection_pool.cpp
+++ b/src/mysql_connection_pool.cpp
@@ -36,44 +36,11 @@ std::unique_ptr<MySQLConnection> MySQLConnectionPool::CreateNewConnection() {
 }
 
 bool MySQLConnectionPool::CheckConnectionHealthy(MySQLConnection &conn) {
-	if (!conn.IsOpen()) {
-		return false;
-	}
-
-	MYSQL *mysql_conn = conn.GetConn();
-	if (mysql_ping(mysql_conn) != 0) {
-		unsigned int err = mysql_errno(mysql_conn);
-		(void)err;
-		return false;
-	}
-	return true;
+	return conn.IsConnectionHealthy();
 }
 
 void MySQLConnectionPool::ResetConnection(MySQLConnection &conn) {
-	MYSQL *mysql_conn = conn.GetConn();
-
-#if defined(MARIADB_VERSION_ID) || (defined(MYSQL_VERSION_ID) && MYSQL_VERSION_ID >= 50703)
-	if (mysql_reset_connection(mysql_conn) != 0) {
-		throw IOException("Failed to reset MySQL connection: %s", mysql_error(mysql_conn));
-	}
-#else
-	if (mysql_change_user(mysql_conn, nullptr, nullptr, nullptr) != 0) {
-		throw IOException("Failed to reset MySQL connection: %s", mysql_error(mysql_conn));
-	}
-#endif
-
-	if (mysql_query(mysql_conn, "SET autocommit=1") != 0) {
-		throw IOException("Failed to set autocommit after connection reset: %s", mysql_error(mysql_conn));
-	}
-
-	if (mysql_set_character_set(mysql_conn, "utf8mb4") != 0) {
-		throw IOException("Failed to set character set after connection reset: %s", mysql_error(mysql_conn));
-	}
-
-	const char *charset = mysql_character_set_name(mysql_conn);
-	if (strcmp(charset, "utf8mb4") != 0) {
-		throw IOException("Character set verification failed: expected utf8mb4, got %s", charset);
-	}
+	conn.Reset();
 }
 
 //===--------------------------------------------------------------------===//
@@ -111,18 +78,15 @@ void MySQLConnectionPool::CalibrateNetwork(MySQLConnection &conn) {
 	static constexpr int NUM_SAMPLES = 3;
 	double total_latency_ms = 0.0;
 
-	MYSQL *mysql_conn = conn.GetConn();
 	for (int i = 0; i < NUM_SAMPLES; i++) {
 		auto start = std::chrono::steady_clock::now();
-		if (mysql_query(mysql_conn, "SELECT 1") != 0) {
+		try {
+			conn.Query("SELECT 1", MySQLResultStreaming::FORCE_MATERIALIZATION);
+		} catch (...) {
 			lock_guard<mutex> lock(calibration_lock);
 			network_calibration.calibration_failed = true;
 			Printer::Print("Warning: MySQL network calibration failed (latency probe error), using default values\n");
 			return;
-		}
-		MYSQL_RES *result = mysql_store_result(mysql_conn);
-		if (result) {
-			mysql_free_result(result);
 		}
 		auto end = std::chrono::steady_clock::now();
 		double elapsed_ms = std::chrono::duration<double, std::milli>(end - start).count();
@@ -135,20 +99,14 @@ void MySQLConnectionPool::CalibrateNetwork(MySQLConnection &conn) {
 	double bandwidth_mbps = NetworkCalibration::DEFAULT_BANDWIDTH_MBPS;
 
 	auto bw_start = std::chrono::steady_clock::now();
-	if (mysql_query(mysql_conn, "SELECT REPEAT('x', 65536)") == 0) {
-		MYSQL_RES *bw_result = mysql_store_result(mysql_conn);
-		if (bw_result) {
-			mysql_fetch_row(bw_result);
-			mysql_free_result(bw_result);
-		}
-		auto bw_end = std::chrono::steady_clock::now();
-		double bw_elapsed_s = std::chrono::duration<double>(bw_end - bw_start).count();
-		double transfer_s = bw_elapsed_s - (avg_latency_ms / 1000.0);
-		if (transfer_s > 0.0001) {
-			bandwidth_mbps =
-			    (static_cast<double>(BANDWIDTH_PAYLOAD_BYTES) / NetworkCalibration::MBPS_TO_BYTES_PER_SEC) / transfer_s;
-			bandwidth_mbps = std::max(bandwidth_mbps, 1.0);
-		}
+	conn.Query("SELECT REPEAT('x', 65536)", MySQLResultStreaming::FORCE_MATERIALIZATION);
+	auto bw_end = std::chrono::steady_clock::now();
+	double bw_elapsed_s = std::chrono::duration<double>(bw_end - bw_start).count();
+	double transfer_s = bw_elapsed_s - (avg_latency_ms / 1000.0);
+	if (transfer_s > 0.0001) {
+		bandwidth_mbps =
+		    (static_cast<double>(BANDWIDTH_PAYLOAD_BYTES) / NetworkCalibration::MBPS_TO_BYTES_PER_SEC) / transfer_s;
+		bandwidth_mbps = std::max(bandwidth_mbps, 1.0);
 	}
 
 	{

--- a/src/mysql_result.cpp
+++ b/src/mysql_result.cpp
@@ -51,10 +51,11 @@ static vector<LogicalType> CreateChunkTypes(vector<MySQLField> &fields, const My
 	return ltypes;
 }
 
-MySQLResult::MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, MySQLTypeConfig type_config_p,
-                         const string &connection_string_p, unsigned long connection_id_p,
-                         MySQLResultStreaming streaming_p, idx_t affected_rows_p, vector<MySQLField> fields_p)
-    : query(query_p), stmt(std::move(stmt_p)), type_config(std::move(type_config_p)),
+MySQLResult::MySQLResult(mutex &query_lock_p, const std::string &query_p, MySQLStatementPtr stmt_p,
+                         MySQLTypeConfig type_config_p, const string &connection_string_p,
+                         unsigned long connection_id_p, MySQLResultStreaming streaming_p, idx_t affected_rows_p,
+                         vector<MySQLField> fields_p)
+    : query_lock(query_lock_p), query(query_p), stmt(std::move(stmt_p)), type_config(std::move(type_config_p)),
       connection_string(connection_string_p), connection_id(connection_id_p), streaming(streaming_p),
       affected_rows(affected_rows_p), fields(std::move(fields_p)) {
 	if (affected_rows != static_cast<idx_t>(-1)) {
@@ -143,6 +144,8 @@ bool MySQLResult::FetchNext() {
 #endif
 		f.ResetBind();
 	}
+
+	lock_guard<mutex> guard(query_lock);
 
 	int res = mysql_stmt_fetch(stmt.get());
 

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -63,16 +63,19 @@ void MySQLTransaction::EnsureConnection() {
 	if (pooled_connection) {
 		return;
 	}
-	pooled_connection = catalog.GetConnectionPool().Acquire(acquire_mode, time_zone);
+
+	auto pc = catalog.GetConnectionPool().Acquire(acquire_mode, time_zone);
+
+	auto ctx = context.lock();
+	if (ctx) {
+		pc.GetConnection().SetTypeConfig(MySQLTypeConfig(*ctx));
+	}
+
+	this->pooled_connection = std::move(pc);
 }
 
 MySQLConnection &MySQLTransaction::GetConnection() {
 	EnsureConnection();
-
-	auto ctx = context.lock();
-	if (ctx) {
-		pooled_connection.GetConnection().SetTypeConfig(MySQLTypeConfig(*ctx));
-	}
 
 	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
 		transaction_state = MySQLTransactionState::TRANSACTION_STARTED;


### PR DESCRIPTION
This is a follow-up PR to #254 that is intended to fix the potential concurrency problems around the concurrent usage of a `libmariadb` connection that is shared between DuckDB worker threads.

Testing: no new tests, thread-sanizer issue uncovered by #254 test is fixed.