### PR TITLE
Fix transaction state transitions

### DIFF
--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -25,10 +25,9 @@ inline void MySQLResultDelete(MYSQL_RES *res) {
 
 class MySQLResult {
 public:
-	MySQLResult(mutex &query_lock_p, const std::string &query_p, MySQLStatementPtr stmt_p,
-	            MySQLTypeConfig type_config_p, const string &connection_string_p, unsigned long connection_id_p,
-	            MySQLResultStreaming streaming_p, idx_t affected_rows_p,
-	            vector<MySQLField> fields_p = vector<MySQLField>());
+	MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, MySQLTypeConfig type_config_p,
+	            const string &connection_string_p, unsigned long connection_id_p, MySQLResultStreaming streaming_p,
+	            idx_t affected_rows_p, vector<MySQLField> fields_p = vector<MySQLField>());
 
 	~MySQLResult();
 
@@ -44,7 +43,6 @@ public:
 	const vector<MySQLField> &Fields();
 
 private:
-	mutex &query_lock;
 	string query;
 	MySQLStatementPtr stmt;
 	MySQLTypeConfig type_config;

--- a/src/include/storage/mysql_transaction.hpp
+++ b/src/include/storage/mysql_transaction.hpp
@@ -36,12 +36,14 @@ public:
 
 private:
 	void EnsureConnection();
+	void StartTransactionInternal();
 
 	MySQLCatalog &catalog;
 	MySQLPooledConnection pooled_connection;
 	mutex pooled_connection_lock;
 	bool transactions_enabled = true;
 	MySQLTransactionState transaction_state = MySQLTransactionState::TRANSACTION_NOT_YET_STARTED;
+	mutex transaction_state_lock;
 	AccessMode access_mode;
 	string time_zone;
 	dbconnector::pool::AcquireMode acquire_mode = dbconnector::pool::AcquireMode::FORCE;

--- a/src/mysql_connection.cpp
+++ b/src/mysql_connection.cpp
@@ -129,7 +129,7 @@ unique_ptr<MySQLResult> MySQLConnection::QueryInternal(const string &query, cons
 
 	auto stmt = MySQLStatementPtr(nullptr, MySQLStatementDelete);
 	{
-		lock_guard<mutex> l(query_lock);
+		lock_guard<mutex> guard(query_lock);
 		stmt = MySQLStatementPtr(mysql_stmt_init(con), MySQLStatementDelete);
 		if (!stmt) {
 			throw IOException("Failed to initialize MySQL query \"%s\": %s\n", query.c_str(), mysql_error(con));
@@ -138,8 +138,8 @@ unique_ptr<MySQLResult> MySQLConnection::QueryInternal(const string &query, cons
 
 	idx_t affected_rows = MySQLExecute(stmt.get(), query, params, result_streaming);
 	unsigned long connection_id = connection->GetID();
-	return make_uniq<MySQLResult>(query_lock, query, std::move(stmt), type_config, connection_string, connection_id,
-	                              streaming, affected_rows);
+	return make_uniq<MySQLResult>(query, std::move(stmt), type_config, connection_string, connection_id, streaming,
+	                              affected_rows);
 }
 
 unique_ptr<MySQLResult> MySQLConnection::Query(const string &query, MySQLResultStreaming streaming) {
@@ -159,12 +159,12 @@ unique_ptr<MySQLResult> MySQLConnection::Query(MySQLStatement &stmt, const vecto
 	idx_t affected_rows = MySQLExecute(stmt.get(), stmt.Query(), params, result_streaming, prepared);
 	auto stmt_ptr = stmt.release();
 	unsigned long connection_id = connection->GetID();
-	return make_uniq<MySQLResult>(query_lock, stmt.Query(), std::move(stmt_ptr), type_config, connection_string,
-	                              connection_id, streaming, affected_rows, stmt.FieldsCopy());
+	return make_uniq<MySQLResult>(stmt.Query(), std::move(stmt_ptr), type_config, connection_string, connection_id,
+	                              streaming, affected_rows, stmt.FieldsCopy());
 }
 
 unique_ptr<MySQLStatement> MySQLConnection::Prepare(const string &query) {
-	lock_guard<mutex> l(query_lock);
+	lock_guard<mutex> guard(query_lock);
 	auto con = GetConn();
 
 	auto stmt = MySQLStatementPtr(mysql_stmt_init(con), MySQLStatementDelete);

--- a/src/mysql_result.cpp
+++ b/src/mysql_result.cpp
@@ -51,11 +51,10 @@ static vector<LogicalType> CreateChunkTypes(vector<MySQLField> &fields, const My
 	return ltypes;
 }
 
-MySQLResult::MySQLResult(mutex &query_lock_p, const std::string &query_p, MySQLStatementPtr stmt_p,
-                         MySQLTypeConfig type_config_p, const string &connection_string_p,
-                         unsigned long connection_id_p, MySQLResultStreaming streaming_p, idx_t affected_rows_p,
-                         vector<MySQLField> fields_p)
-    : query_lock(query_lock_p), query(query_p), stmt(std::move(stmt_p)), type_config(std::move(type_config_p)),
+MySQLResult::MySQLResult(const std::string &query_p, MySQLStatementPtr stmt_p, MySQLTypeConfig type_config_p,
+                         const string &connection_string_p, unsigned long connection_id_p,
+                         MySQLResultStreaming streaming_p, idx_t affected_rows_p, vector<MySQLField> fields_p)
+    : query(query_p), stmt(std::move(stmt_p)), type_config(std::move(type_config_p)),
       connection_string(connection_string_p), connection_id(connection_id_p), streaming(streaming_p),
       affected_rows(affected_rows_p), fields(std::move(fields_p)) {
 	if (affected_rows != static_cast<idx_t>(-1)) {
@@ -144,8 +143,6 @@ bool MySQLResult::FetchNext() {
 #endif
 		f.ResetBind();
 	}
-
-	lock_guard<mutex> guard(query_lock);
 
 	int res = mysql_stmt_fetch(stmt.get());
 

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -30,14 +30,21 @@ MySQLTransaction::MySQLTransaction(MySQLCatalog &mysql_catalog, TransactionManag
 MySQLTransaction::~MySQLTransaction() = default;
 
 void MySQLTransaction::Start() {
+	lock_guard<mutex> guard(transaction_state_lock);
 	transaction_state = MySQLTransactionState::TRANSACTION_NOT_YET_STARTED;
 }
 
 void MySQLTransaction::Commit() {
-	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
-		transaction_state = MySQLTransactionState::TRANSACTION_FINISHED;
+	if (!transactions_enabled) {
+		return;
+	}
+
+	lock_guard<mutex> guard(transaction_state_lock);
+
+	if (transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
 		try {
 			pooled_connection.GetConnection().Execute("COMMIT");
+			transaction_state = MySQLTransactionState::TRANSACTION_FINISHED;
 		} catch (...) {
 			pooled_connection.Invalidate();
 			throw;
@@ -46,10 +53,16 @@ void MySQLTransaction::Commit() {
 }
 
 void MySQLTransaction::Rollback() {
-	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
-		transaction_state = MySQLTransactionState::TRANSACTION_FINISHED;
+	if (!transactions_enabled) {
+		return;
+	}
+
+	lock_guard<mutex> guard(transaction_state_lock);
+
+	if (transaction_state == MySQLTransactionState::TRANSACTION_STARTED) {
 		try {
 			pooled_connection.GetConnection().Execute("ROLLBACK");
+			transaction_state = MySQLTransactionState::TRANSACTION_FINISHED;
 		} catch (...) {
 			pooled_connection.Invalidate();
 			throw;
@@ -74,42 +87,41 @@ void MySQLTransaction::EnsureConnection() {
 	this->pooled_connection = std::move(pc);
 }
 
-MySQLConnection &MySQLTransaction::GetConnection() {
-	EnsureConnection();
+void MySQLTransaction::StartTransactionInternal() {
+	if (!transactions_enabled) {
+		return;
+	}
 
-	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
-		transaction_state = MySQLTransactionState::TRANSACTION_STARTED;
+	lock_guard<mutex> guard(transaction_state_lock);
+
+	if (transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
 		string query = "START TRANSACTION";
 		if (access_mode == AccessMode::READ_ONLY) {
 			query += " READ ONLY";
 		}
 		try {
 			pooled_connection.GetConnection().Execute(query);
+			transaction_state = MySQLTransactionState::TRANSACTION_STARTED;
 		} catch (...) {
 			pooled_connection.Invalidate();
 			throw;
 		}
 	}
+}
+
+MySQLConnection &MySQLTransaction::GetConnection() {
+	EnsureConnection();
+
+	StartTransactionInternal();
+
 	return pooled_connection.GetConnection();
 }
 
 unique_ptr<MySQLResult> MySQLTransaction::Query(const string &query) {
 	EnsureConnection();
 
-	if (transactions_enabled && transaction_state == MySQLTransactionState::TRANSACTION_NOT_YET_STARTED) {
-		transaction_state = MySQLTransactionState::TRANSACTION_STARTED;
-		string transaction_start = "START TRANSACTION";
-		if (access_mode == AccessMode::READ_ONLY) {
-			transaction_start += " READ ONLY";
-		}
-		try {
-			pooled_connection.GetConnection().Execute(transaction_start);
-			return pooled_connection.GetConnection().Query(query, MySQLResultStreaming::FORCE_MATERIALIZATION);
-		} catch (...) {
-			pooled_connection.Invalidate();
-			throw;
-		}
-	}
+	StartTransactionInternal();
+
 	try {
 		return pooled_connection.GetConnection().Query(query, MySQLResultStreaming::FORCE_MATERIALIZATION);
 	} catch (...) {


### PR DESCRIPTION
This PR is a follow-up to #254, it fixes the data race problem with transaction state transitions, when multiple MySQL scans are started concurrently.

Additionally it removes the locking in results fetch, that appeared to be unnecessary (no concurrent IO, won't help from concurrent closure).

Testing: no new tests, fixes the thread-sanitizer problem with #254 test.