### PR TITLE
Allow to use filter pushdown without analyzer

### DIFF
--- a/.github/workflows/MysqlTests.yml
+++ b/.github/workflows/MysqlTests.yml
@@ -108,6 +108,7 @@ jobs:
       env: 
         LOCAL_EXTENSION_REPO: ${{ github.workspace }}/build/release/repository/
         MYSQL_TEST_DATABASE_AVAILABLE: 1
+        MYSQL_TEST_PREDICATE_ANALYZER: 1
         MARIADB_SERVER: 1
       run: |
         make test
@@ -187,6 +188,7 @@ jobs:
         env:
           LOCAL_EXTENSION_REPO: ${{ github.workspace }}/build/release/repository/
           MYSQL_TEST_DATABASE_AVAILABLE: 1
+          MYSQL_TEST_PREDICATE_ANALYZER: 1
           ORACLE_MYSQL_SERVER: 1
         run: |
           make test

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ SELECT * FROM mysql_db.tmp;
 ## Settings
 |                name                |                          description                           | default |
 |------------------------------------|----------------------------------------------------------------|---------|
-| mysql_experimental_filter_pushdown | Whether or not to use filter pushdown (currently experimental) | true    |
+| mysql_experimental_filter_pushdown | Whether or not to use filter pushdown (without predicate analyzer) | true    |
+| mysql_enable_predicate_analyzer    | Whether or not to use predicate analyzer with cost-based pushdowns | false   |
 | mysql_tinyint1_as_boolean          | Whether or not to convert TINYINT(1) columns to BOOLEAN        | true    |
 | mysql_debug_show_queries           | DEBUG SETTING: print all queries sent to MySQL to stdout       | false   |
 | mysql_bit1_as_boolean              | Whether or not to convert BIT(1) columns to BOOLEAN            | true    |

--- a/benchmarks/federation_speed_benchmark.sql
+++ b/benchmarks/federation_speed_benchmark.sql
@@ -33,7 +33,7 @@ CALL mysql_execute('s1', 'ANALYZE TABLE bench_speed');
 SELECT '=== BENCHMARK 1: PK Point Lookup (1/50000 rows) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed WHERE id = 25000;
@@ -41,7 +41,7 @@ SELECT id, indexed_col FROM s1.bench_speed WHERE id = 25000;
 SELECT id, indexed_col FROM s1.bench_speed WHERE id = 25000;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed WHERE id = 25000;
@@ -51,7 +51,7 @@ SELECT id, indexed_col FROM s1.bench_speed WHERE id = 25000;
 SELECT '=== BENCHMARK 2: Indexed Equality (500/50000 rows, 1%) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 42;
@@ -59,7 +59,7 @@ SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 42;
 SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 42;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 42;
@@ -69,7 +69,7 @@ SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 42;
 SELECT '=== BENCHMARK 3: Compound Filter (~170/50000 rows, 0.33%) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 10 AND status = 'active';
@@ -77,7 +77,7 @@ SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 10 AND status = '
 SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 10 AND status = 'active';
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 10 AND status = 'active';
@@ -87,7 +87,7 @@ SELECT id, indexed_col FROM s1.bench_speed WHERE indexed_col = 10 AND status = '
 SELECT '=== BENCHMARK 4: COUNT(*) Full Table (50000 rows) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT COUNT(*) FROM s1.bench_speed;
@@ -95,7 +95,7 @@ SELECT COUNT(*) FROM s1.bench_speed;
 SELECT COUNT(*) FROM s1.bench_speed;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT COUNT(*) FROM s1.bench_speed;
@@ -105,7 +105,7 @@ SELECT COUNT(*) FROM s1.bench_speed;
 SELECT '=== BENCHMARK 5: COUNT(*) with WHERE (500/50000 rows) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT COUNT(*) FROM s1.bench_speed WHERE indexed_col = 77;
@@ -113,7 +113,7 @@ SELECT COUNT(*) FROM s1.bench_speed WHERE indexed_col = 77;
 SELECT COUNT(*) FROM s1.bench_speed WHERE indexed_col = 77;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT COUNT(*) FROM s1.bench_speed WHERE indexed_col = 77;
@@ -123,7 +123,7 @@ SELECT COUNT(*) FROM s1.bench_speed WHERE indexed_col = 77;
 SELECT '=== BENCHMARK 6: ORDER BY + LIMIT 5 (out of 50K rows) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed ORDER BY indexed_col, id LIMIT 5;
@@ -131,7 +131,7 @@ SELECT id, indexed_col FROM s1.bench_speed ORDER BY indexed_col, id LIMIT 5;
 SELECT id, indexed_col FROM s1.bench_speed ORDER BY indexed_col, id LIMIT 5;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT id, indexed_col FROM s1.bench_speed ORDER BY indexed_col, id LIMIT 5;
@@ -141,7 +141,7 @@ SELECT id, indexed_col FROM s1.bench_speed ORDER BY indexed_col, id LIMIT 5;
 SELECT '=== BENCHMARK 7: SUM(id) with WHERE (500/50000 rows) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT SUM(id) FROM s1.bench_speed WHERE indexed_col = 0;
@@ -149,7 +149,7 @@ SELECT SUM(id) FROM s1.bench_speed WHERE indexed_col = 0;
 SELECT SUM(id) FROM s1.bench_speed WHERE indexed_col = 0;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT SUM(id) FROM s1.bench_speed WHERE indexed_col = 0;
@@ -159,7 +159,7 @@ SELECT SUM(id) FROM s1.bench_speed WHERE indexed_col = 0;
 SELECT '=== BENCHMARK 8: Full Table Scan — no WHERE (50K rows) ===' AS benchmark;
 
 SELECT '--- Federation ON ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 CALL mysql_clear_cache();
 
 SELECT COUNT(id) FROM s1.bench_speed WHERE indexed_col >= 0;
@@ -167,7 +167,7 @@ SELECT COUNT(id) FROM s1.bench_speed WHERE indexed_col >= 0;
 SELECT COUNT(id) FROM s1.bench_speed WHERE indexed_col >= 0;
 
 SELECT '--- Federation OFF ---' AS mode;
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 CALL mysql_clear_cache();
 
 SELECT COUNT(id) FROM s1.bench_speed WHERE indexed_col >= 0;
@@ -177,4 +177,4 @@ SELECT COUNT(id) FROM s1.bench_speed WHERE indexed_col >= 0;
 SELECT '=== CLEANUP ===' AS info;
 DROP TABLE IF EXISTS s1.bench_speed;
 
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;

--- a/benchmarks/run_speed_benchmark.sh
+++ b/benchmarks/run_speed_benchmark.sh
@@ -176,7 +176,7 @@ time_query() {
     output=$("$DUCKDB" -unsigned -csv -noheader -c "
         ATTACH '$CONN_STRING' AS loader (TYPE MYSQL_SCANNER);
         DETACH loader;
-        SET GLOBAL mysql_experimental_filter_pushdown=$mode;
+        SET GLOBAL mysql_enable_predicate_analyzer=$mode;
         ATTACH '$CONN_STRING' AS s1 (TYPE MYSQL_SCANNER);
         CALL mysql_clear_cache();
         $query;

--- a/src/include/mysql_filter_pushdown.hpp
+++ b/src/include/mysql_filter_pushdown.hpp
@@ -19,11 +19,11 @@ public:
 	static string TransformFilters(const vector<column_t> &column_ids, optional_ptr<TableFilterSet> filters,
 	                               const vector<string> &names);
 
-	static string TransformFilter(string &column_name, TableFilter &filter);
+	static string TransformFilter(const string &column_name, TableFilter &filter);
 
 private:
 	static string TransformComparison(ExpressionType type);
-	static string CreateExpression(string &column_name, vector<unique_ptr<TableFilter>> &filters, string op);
+	static string CreateExpression(const string &column_name, vector<unique_ptr<TableFilter>> &filters, string op);
 };
 
 } // namespace duckdb

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -155,8 +155,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	StorageExtension::Register(config, "mysql_scanner", make_shared_ptr<MySQLStorageExtension>());
 
 	config.AddExtensionOption("mysql_experimental_filter_pushdown",
-	                          "Whether or not to use filter pushdown (currently experimental)", LogicalType::BOOLEAN,
-	                          Value::BOOLEAN(true));
+	                          "Whether or not to use filter pushdown (without predicate analyzer)",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	config.AddExtensionOption("mysql_enable_predicate_analyzer",
+	                          "Whether or not to use predicate analyzer with cost-based pushdowns",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
 	config.AddExtensionOption("mysql_debug_show_queries", "DEBUG SETTING: print all queries sent to MySQL to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetMySQLDebugQueryPrint);
 	config.AddExtensionOption("mysql_tinyint1_as_boolean", "Whether or not to convert TINYINT(1) columns to BOOLEAN",

--- a/src/mysql_filter_pushdown.cpp
+++ b/src/mysql_filter_pushdown.cpp
@@ -5,7 +5,8 @@
 
 namespace duckdb {
 
-string MySQLFilterPushdown::CreateExpression(string &column_name, vector<unique_ptr<TableFilter>> &filters, string op) {
+string MySQLFilterPushdown::CreateExpression(const string &column_name, vector<unique_ptr<TableFilter>> &filters,
+                                             string op) {
 	vector<string> filter_entries;
 	for (auto &filter : filters) {
 		auto new_filter = TransformFilter(column_name, *filter);
@@ -39,7 +40,7 @@ string MySQLFilterPushdown::TransformComparison(ExpressionType type) {
 	}
 }
 
-string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &filter) {
+string MySQLFilterPushdown::TransformFilter(const string &column_name, TableFilter &filter) {
 	switch (filter.filter_type) {
 	case TableFilterType::IS_NULL:
 		return column_name + " IS NULL";

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -361,6 +361,35 @@ static void ConfigureAdaptiveFeedback(ClientContext &context, MySQLGlobalState &
 	}
 }
 
+static string BuildAggregateQuery(const MySQLBindData &bind_data) {
+	string sql = "SELECT " + bind_data.aggregate_select_list;
+	sql += " FROM ";
+	sql += MySQLUtils::WriteIdentifier(bind_data.table.schema.name);
+	sql += ".";
+	sql += MySQLUtils::WriteIdentifier(bind_data.table.name);
+	if (!bind_data.aggregate_where_clause.empty()) {
+		sql += " WHERE " + bind_data.aggregate_where_clause;
+	}
+	if (!bind_data.group_by_clause.empty()) {
+		sql += bind_data.group_by_clause;
+	}
+	if (!bind_data.order_by_clause.empty()) {
+		sql += bind_data.order_by_clause;
+	}
+	if (!bind_data.limit.empty()) {
+		sql += bind_data.limit;
+	}
+	return sql;
+}
+
+static bool HintInjectionEnabled(ClientContext &context) {
+	Value hint_injection_enabled_val;
+	if (context.TryGetCurrentSetting("mysql_hint_injection_enabled", hint_injection_enabled_val)) {
+		return BooleanValue::Get(hint_injection_enabled_val);
+	}
+	return false;
+}
+
 static unique_ptr<GlobalTableFunctionState> MySQLInitGlobalState(ClientContext &context,
                                                                  TableFunctionInitInput &input) {
 	const auto &bind_data = input.bind_data->Cast<MySQLBindData>();
@@ -371,42 +400,16 @@ static unique_ptr<GlobalTableFunctionState> MySQLInitGlobalState(ClientContext &
 	auto &mysql_catalog = bind_data.table.catalog.Cast<MySQLCatalog>();
 
 	if (bind_data.has_aggregate_pushdown) {
-		auto build_aggregate_query = [&]() {
-			string sql = "SELECT " + bind_data.aggregate_select_list;
-			sql += " FROM ";
-			sql += MySQLUtils::WriteIdentifier(bind_data.table.schema.name);
-			sql += ".";
-			sql += MySQLUtils::WriteIdentifier(bind_data.table.name);
-			if (!bind_data.aggregate_where_clause.empty()) {
-				sql += " WHERE " + bind_data.aggregate_where_clause;
-			}
-			if (!bind_data.group_by_clause.empty()) {
-				sql += bind_data.group_by_clause;
-			}
-			if (!bind_data.order_by_clause.empty()) {
-				sql += bind_data.order_by_clause;
-			}
-			if (!bind_data.limit.empty()) {
-				sql += bind_data.limit;
-			}
-			return sql;
-		};
+		string select = BuildAggregateQuery(bind_data);
 
-		string select = build_aggregate_query();
-		FederationState agg_fed;
-		agg_fed.adaptive_estimated_rows = 0;
-		agg_fed.execution_plan.estimated_cost.cpu_cost = static_cast<double>(MIN_QUERY_TIMEOUT_MS);
-		InjectQueryHints(context, select, agg_fed, bind_data, con, mysql_catalog.GetStatsCache());
-		try {
-			auto query_result = con.Query(select, MySQLResultStreaming::FORCE_MATERIALIZATION);
-			return make_uniq<MySQLGlobalState>(std::move(query_result));
-		} catch (std::bad_alloc &) {
-			throw;
-		} catch (std::exception &) {
-			string fallback = build_aggregate_query();
-			auto query_result = con.Query(fallback, MySQLResultStreaming::FORCE_MATERIALIZATION);
-			return make_uniq<MySQLGlobalState>(std::move(query_result));
+		if (bind_data.use_predicate_analyzer && HintInjectionEnabled(context)) {
+			FederationState agg_fed;
+			agg_fed.adaptive_estimated_rows = 0;
+			agg_fed.execution_plan.estimated_cost.cpu_cost = static_cast<double>(MIN_QUERY_TIMEOUT_MS);
+			InjectQueryHints(context, select, agg_fed, bind_data, con, mysql_catalog.GetStatsCache());
 		}
+		auto query_result = con.Query(select, MySQLResultStreaming::FORCE_MATERIALIZATION);
+		return make_uniq<MySQLGlobalState>(std::move(query_result));
 	}
 
 	string select;
@@ -499,7 +502,7 @@ static unique_ptr<GlobalTableFunctionState> MySQLInitGlobalState(ClientContext &
 		select += bind_data.limit;
 	}
 
-	if (bind_data.use_predicate_analyzer) {
+	if (bind_data.use_predicate_analyzer && HintInjectionEnabled(context)) {
 		InjectQueryHints(context, select, fed, bind_data, con, mysql_catalog.GetStatsCache());
 	}
 

--- a/src/storage/mysql_optimizer.cpp
+++ b/src/storage/mysql_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "storage/mysql_optimizer.hpp"
 #include "storage/mysql_catalog.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
@@ -399,6 +400,13 @@ static void RewriteBindingsInOperator(LogicalOperator &op, AggregateRewriteInfo 
 		auto &topn = op.Cast<LogicalTopN>();
 		for (auto &node : topn.orders) {
 			RewriteExpression(node.expression, info);
+		}
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		for (auto &cond : join.conditions) {
+			RewriteExpression(cond.left, info);
+			RewriteExpression(cond.right, info);
 		}
 	}
 }

--- a/src/storage/mysql_predicate_analyzer.cpp
+++ b/src/storage/mysql_predicate_analyzer.cpp
@@ -1,4 +1,5 @@
 #include "storage/mysql_predicate_analyzer.hpp"
+#include "mysql_filter_pushdown.hpp"
 #include "mysql_utils.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
@@ -233,7 +234,8 @@ PredicateAnalysis PredicateAnalyzer::AnalyzeFilter(const string &column_name, Ta
 	PredicateAnalysis result;
 	result.column_name = column_name;
 
-	if (!CanPushFilter(filter)) {
+	result.mysql_predicate = MySQLFilterPushdown::TransformFilter(column_name, filter);
+	if (result.mysql_predicate.empty()) {
 		result.decision = PushdownDecision::EXECUTE_IN_DUCKDB;
 		result.estimated_selectivity = DEFAULT_SELECTIVITY;
 #ifndef NDEBUG
@@ -250,11 +252,6 @@ PredicateAnalysis PredicateAnalyzer::AnalyzeFilter(const string &column_name, Ta
 		result.decision = PushdownDecision::PUSH_TO_MYSQL;
 	} else {
 		result.decision = MakePushdownDecision(result.estimated_selectivity, result.has_index);
-	}
-
-	result.mysql_predicate = TransformFilterToMySQL(column_name, filter);
-	if (result.mysql_predicate.empty()) {
-		result.decision = PushdownDecision::EXECUTE_IN_DUCKDB;
 	}
 
 #ifndef NDEBUG

--- a/src/storage/mysql_table_entry.cpp
+++ b/src/storage/mysql_table_entry.cpp
@@ -85,24 +85,26 @@ void MySQLTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &, Logica
                                             ClientContext &) {
 }
 
+static bool GetBoolSetting(ClientContext &context, const std::string &name) {
+	Value val;
+	if (context.TryGetCurrentSetting(name, val)) {
+		return BooleanValue::Get(val);
+	}
+	return false;
+}
+
 TableFunction MySQLTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
 	auto result = make_uniq<MySQLBindData>(*this);
 	for (auto &col : columns.Logical()) {
 		result->types.push_back(col.GetType());
 		result->names.push_back(col.GetName());
 	}
-
-	Value filter_pushdown;
-	bool pushdown_enabled = false;
-	if (context.TryGetCurrentSetting("mysql_experimental_filter_pushdown", filter_pushdown)) {
-		pushdown_enabled = BooleanValue::Get(filter_pushdown);
-	}
-	result->use_predicate_analyzer = pushdown_enabled;
-
+	bool use_predicate_analyzer = GetBoolSetting(context, "mysql_enable_predicate_analyzer");
+	result->use_predicate_analyzer = use_predicate_analyzer;
 	bind_data = std::move(result);
 
 	auto function = MySQLScanFunction();
-	function.filter_pushdown = pushdown_enabled;
+	function.filter_pushdown = use_predicate_analyzer || GetBoolSetting(context, "mysql_experimental_filter_pushdown");
 	return function;
 }
 

--- a/test/sql/attach_aggregate_pushdown.test
+++ b/test/sql/attach_aggregate_pushdown.test
@@ -10,6 +10,9 @@ statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
 
 statement ok
+SET mysql_aggregate_pushdown_enabled = TRUE
+
+statement ok
 DROP TABLE IF EXISTS s1.agg_test;
 
 statement ok

--- a/test/sql/attach_create_index.test
+++ b/test/sql/attach_create_index.test
@@ -10,16 +10,16 @@ statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
 
 statement ok
-CREATE OR REPLACE TABLE s.test(i INTEGER);
+CREATE OR REPLACE TABLE s.test_index(i INTEGER);
 
 statement ok
-INSERT INTO s.test VALUES (1), (2), (3);
+INSERT INTO s.test_index VALUES (1), (2), (3);
 
 statement ok
-CREATE INDEX i_index ON s.test(i);
+CREATE INDEX i_index ON s.test_index(i);
 
 query I
-SELECT * FROM s.test WHERE i=2
+SELECT * FROM s.test_index WHERE i=2
 ----
 2
 
@@ -40,35 +40,35 @@ statement ok
 DROP INDEX IF EXISTS s.i_index;
 
 statement ok
-DROP TABLE s.test;
+DROP TABLE s.test_index;
 
 # multi-dimensional index
 statement ok
-CREATE TABLE s.test(i INTEGER, j INTEGER);
+CREATE TABLE s.test_index(i INTEGER, j INTEGER);
 
 statement ok
-INSERT INTO s.test VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO s.test_index VALUES (1, 10), (2, 20), (3, 30);
 
 statement ok
-CREATE INDEX i_index ON s.test(i, j);
+CREATE INDEX i_index ON s.test_index(i, j);
 
 query II
-SELECT * FROM s.test WHERE i=2 AND j=20
+SELECT * FROM s.test_index WHERE i=2 AND j=20
 ----
 2	20
 
 statement ok
-DROP TABLE s.test CASCADE
+DROP TABLE s.test_index CASCADE
 
 # index with a function
 statement ok
-CREATE TABLE s.test(s VARCHAR);
+CREATE TABLE s.test_index(s VARCHAR);
 
 statement ok
-INSERT INTO s.test VALUES ('HELLO'), ('hello')
+INSERT INTO s.test_index VALUES ('HELLO'), ('hello')
 
 # cannot create index on blob or text columns
 statement error
-CREATE UNIQUE INDEX i_index ON s.test(LOWER(s))
+CREATE UNIQUE INDEX i_index ON s.test_index(LOWER(s))
 ----
 <REGEX>:.*(that returns a BLOB or TEXT|MariaDB).*

--- a/test/sql/attach_fake_booleans.test
+++ b/test/sql/attach_fake_booleans.test
@@ -7,9 +7,6 @@ require mysql_scanner
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
-
-statement ok
 ATTACH '   host="localhost"  user=root   port=0   database=mysqlscanner   ' AS s1 (TYPE MYSQL_SCANNER)
 
 query II

--- a/test/sql/attach_filter_pushdown.test
+++ b/test/sql/attach_filter_pushdown.test
@@ -7,9 +7,6 @@ require mysql_scanner
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
-
-statement ok
 ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
 
 statement ok

--- a/test/sql/attach_transactions.test
+++ b/test/sql/attach_transactions.test
@@ -10,31 +10,31 @@ statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
 
 statement ok
-DROP TABLE IF EXISTS s.test
+DROP TABLE IF EXISTS s.test_tran
 
 # roll back create table
 statement ok
 BEGIN
 
 statement ok
-CREATE TABLE s.test(i INTEGER);
+CREATE TABLE s.test_tran(i INTEGER);
 
 statement ok
 ROLLBACK
 
 # DDL statements are not transactional in MySQL so rolling back does nothing
 statement ok
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 
 # roll back insert
 statement ok
 BEGIN
 
 statement ok
-INSERT INTO s.test VALUES (42)
+INSERT INTO s.test_tran VALUES (42)
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 42
 
@@ -42,7 +42,7 @@ statement ok
 ROLLBACK
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 
 # commit insert
@@ -50,13 +50,13 @@ statement ok
 BEGIN
 
 statement ok
-INSERT INTO s.test VALUES (1), (2), (3)
+INSERT INTO s.test_tran VALUES (1), (2), (3)
 
 statement ok
 COMMIT
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 2
@@ -67,10 +67,10 @@ statement ok
 BEGIN
 
 statement ok
-DELETE FROM s.test WHERE i=2
+DELETE FROM s.test_tran WHERE i=2
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 3
@@ -79,7 +79,7 @@ statement ok
 ROLLBACK
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 2
@@ -90,10 +90,10 @@ statement ok
 BEGIN
 
 statement ok
-UPDATE s.test SET i=i+100
+UPDATE s.test_tran SET i=i+100
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 101
 102
@@ -103,7 +103,7 @@ statement ok
 ROLLBACK
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 2
@@ -114,13 +114,13 @@ statement ok
 BEGIN
 
 statement ok
-INSERT INTO s.test SELECT 2 FROM range(10000);
+INSERT INTO s.test_tran SELECT 2 FROM range(10000);
 
 statement ok
-DELETE FROM s.test WHERE i=2
+DELETE FROM s.test_tran WHERE i=2
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 3
@@ -129,7 +129,7 @@ statement ok
 ROLLBACK
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 2
@@ -143,20 +143,20 @@ statement ok
 BEGIN
 
 statement ok
-ALTER TABLE s.test ADD COLUMN b INTEGER
+ALTER TABLE s.test_tran ADD COLUMN b INTEGER
 
 query II
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1	NULL
 2	NULL
 3	NULL
 
 statement ok
-UPDATE s.test SET b=i+100 WHERE i!=2
+UPDATE s.test_tran SET b=i+100 WHERE i!=2
 
 query II
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1	101
 2	NULL
@@ -166,7 +166,7 @@ statement ok
 ROLLBACK
 
 query I
-SELECT * FROM s.test
+SELECT * FROM s.test_tran
 ----
 1
 2
@@ -174,7 +174,7 @@ SELECT * FROM s.test
 
 # Cleanup
 statement ok
-DROP TABLE IF EXISTS s.test
+DROP TABLE IF EXISTS s.test_tran
 
 statement ok
 DETACH s

--- a/test/sql/attach_types.test
+++ b/test/sql/attach_types.test
@@ -71,15 +71,15 @@ NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	
 foreach column_name bool tinyint smallint int bigint utinyint usmallint uint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob bit small_enum medium_enum large_enum
 
 statement ok
-SET VARIABLE minimum_value=(SELECT MIN(${column_name}) min_val FROM s.all_types);
+SET VARIABLE minimum_value=(SELECT MIN({column_name}) min_val FROM s.all_types);
 
 query I
-SELECT ANY_VALUE(${column_name})=getvariable('minimum_value') FROM s.all_types WHERE ${column_name}=getvariable('minimum_value')
+SELECT ANY_VALUE({column_name})=getvariable('minimum_value') FROM s.all_types WHERE {column_name}=getvariable('minimum_value')
 ----
 true
 
 query I
-SELECT ANY_VALUE(${column_name})=getvariable('minimum_value') FROM s.all_types WHERE ${column_name} IN (getvariable('minimum_value'), getvariable('minimum_value'))
+SELECT ANY_VALUE({column_name})=getvariable('minimum_value') FROM s.all_types WHERE {column_name} IN (getvariable('minimum_value'), getvariable('minimum_value'))
 ----
 true
 

--- a/test/sql/predicate_analyzer/adaptive_execution.test
+++ b/test/sql/predicate_analyzer/adaptive_execution.test
@@ -1,22 +1,18 @@
-# name: test/sql/adaptive_execution.test
+# name: test/sql/predicate_analyzer/adaptive_execution.test
 # description: Test adaptive execution strategy with plan cache feedback
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
-
-statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS loader (TYPE MYSQL_SCANNER)
-
-statement ok
-DETACH loader
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create table for adaptive testing
 
@@ -120,3 +116,9 @@ SELECT COUNT(*), SUM(value) FROM s1.adaptive_test WHERE category = 5;
 
 statement ok
 DROP TABLE IF EXISTS s1.adaptive_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/compression_cost_model.test
+++ b/test/sql/predicate_analyzer/compression_cost_model.test
@@ -1,16 +1,18 @@
-# name: test/sql/compression_cost_model.test
+# name: test/sql/predicate_analyzer/compression_cost_model.test
 # description: Test compression-aware transfer cost estimation
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create regular and compressed tables
 
@@ -110,3 +112,9 @@ DROP TABLE IF EXISTS s1.uncompressed_data;
 
 statement ok
 DROP TABLE IF EXISTS s1.compressed_data;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/covering_index.test
+++ b/test/sql/predicate_analyzer/covering_index.test
@@ -1,16 +1,18 @@
-# name: test/sql/covering_index.test
+# name: test/sql/predicate_analyzer/covering_index.test
 # description: Test covering index detection for cost model optimization
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create table with various indexes for covering index tests
 
@@ -294,6 +296,9 @@ WHERE indexed_a = 0
 
 statement ok
 DROP TABLE IF EXISTS s1.covering_idx_test
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
 
 statement ok
 DETACH s1

--- a/test/sql/predicate_analyzer/execution_plan_cache.test
+++ b/test/sql/predicate_analyzer/execution_plan_cache.test
@@ -1,16 +1,18 @@
-# name: test/sql/execution_plan_cache.test
+# name: test/sql/predicate_analyzer/execution_plan_cache.test
 # description: Test execution plan caching for repeated queries
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create tables for plan cache testing
 
@@ -181,7 +183,7 @@ statement ok
 CALL mysql_clear_cache()
 
 query I
-SELECT COUNT(*) FROM s1.plan_cache_test1 WHERE category = ${i}
+SELECT COUNT(*) FROM s1.plan_cache_test1 WHERE category = {i}
 ----
 100
 
@@ -244,6 +246,9 @@ DROP TABLE IF EXISTS s1.plan_cache_test1
 
 statement ok
 DROP TABLE IF EXISTS s1.plan_cache_test2
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
 
 statement ok
 DETACH s1

--- a/test/sql/predicate_analyzer/federation_benchmark.test
+++ b/test/sql/predicate_analyzer/federation_benchmark.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_benchmark.test
+# name: test/sql/predicate_analyzer/federation_benchmark.test
 # description: Benchmark tests to validate federation optimizer performance improvements
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port=3306 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # SETUP: Create benchmark table with 10000 rows
 
@@ -329,3 +331,9 @@ DROP TABLE s1.benchmark_lookup
 
 statement ok
 DROP TABLE s1.benchmark_data
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_benchmark_profile.test
+++ b/test/sql/predicate_analyzer/federation_benchmark_profile.test
@@ -1,15 +1,20 @@
-# name: test/sql/federation_benchmark_profile.test
+# name: test/sql/predicate_analyzer/federation_benchmark_profile.test
 # description: Profile-based benchmark to measure federation optimizer effectiveness
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
+require-env MYSQL_TEST_PREDICATE_ANALYZER
+
 # SETUP
 
 statement ok
 ATTACH 'host=localhost user=root port=3306 database=mysqlscanner' AS bench (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 statement ok
 DROP TABLE IF EXISTS bench.perf_test
@@ -48,7 +53,7 @@ SELECT COUNT(*) FROM bench.perf_test
 # TEST 2: Point Lookup - Maximum Pushdown Benefit
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+SET GLOBAL mysql_enable_predicate_analyzer=true
 
 query II
 SELECT id, indexed_col FROM bench.perf_test WHERE id = 5000
@@ -154,7 +159,7 @@ WHERE indexed_col = 75
 # TEST 11: Comparison - With vs Without Pushdown
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+SET GLOBAL mysql_enable_predicate_analyzer=true
 
 query I
 SELECT COUNT(*) FROM bench.perf_test
@@ -163,7 +168,7 @@ WHERE indexed_col = 33 AND LENGTH(data_col) > 40
 100
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false
+SET GLOBAL mysql_enable_predicate_analyzer=false
 
 query I
 SELECT COUNT(*) FROM bench.perf_test
@@ -173,7 +178,7 @@ WHERE indexed_col = 33 AND LENGTH(data_col) > 40
 
 # Re-enable for remaining tests
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+SET GLOBAL mysql_enable_predicate_analyzer=true
 
 # TEST 12: Edge Case - Empty Result from Pushed Filter
 
@@ -197,3 +202,9 @@ WHERE indexed_col >= 0
 
 statement ok
 DROP TABLE bench.perf_test
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH bench

--- a/test/sql/predicate_analyzer/federation_buffer_pool.test
+++ b/test/sql/predicate_analyzer/federation_buffer_pool.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_buffer_pool.test
+# name: test/sql/predicate_analyzer/federation_buffer_pool.test
 # description: Test buffer pool awareness in cost model
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 statement ok
 DROP TABLE IF EXISTS s1.bp_test
@@ -64,6 +66,9 @@ WHERE table_name = 'bp_test'
 
 statement ok
 DROP TABLE IF EXISTS s1.bp_test
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
 
 statement ok
 DETACH s1

--- a/test/sql/predicate_analyzer/federation_comprehensive_benchmark.test
+++ b/test/sql/predicate_analyzer/federation_comprehensive_benchmark.test
@@ -1,28 +1,26 @@
-# name: test/sql/federation_comprehensive_benchmark.test
+# name: test/sql/predicate_analyzer/federation_comprehensive_benchmark.test
 # description: Comprehensive benchmark validating federation optimizer correctness and strategy selection
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
+require-env MYSQL_TEST_PREDICATE_ANALYZER
+
 # SETUP
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
-
-# Force extension load before using custom settings
-statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS loader (TYPE MYSQL_SCANNER)
-
-statement ok
-DETACH loader
-
-statement ok
-SET mysql_adaptive_replan_enabled = true;
-
-statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
+
+statement ok
+SET GLOBAL mysql_hint_injection_enabled = TRUE
+
+statement ok
+SET GLOBAL mysql_adaptive_replan_enabled = TRUE
 
 statement ok
 DROP TABLE IF EXISTS s1.bench_main;
@@ -195,7 +193,7 @@ true
 
 # 3a: Point lookup
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query II
 SELECT id, amount FROM s1.bench_main WHERE id = 12345
@@ -203,7 +201,7 @@ SELECT id, amount FROM s1.bench_main WHERE id = 12345
 12345	345.45
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query II
 SELECT id, amount FROM s1.bench_main WHERE id = 12345
@@ -212,7 +210,7 @@ SELECT id, amount FROM s1.bench_main WHERE id = 12345
 
 # 3b: Indexed range — compare SUM via aggregate pushdown
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query I
 SELECT SUM(id) FROM s1.bench_main WHERE category = 77
@@ -220,7 +218,7 @@ SELECT SUM(id) FROM s1.bench_main WHERE category = 77
 12513500
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query I
 SELECT SUM(id) FROM s1.bench_main WHERE category = 77
@@ -229,7 +227,7 @@ SELECT SUM(id) FROM s1.bench_main WHERE category = 77
 
 # 3c: Hybrid (function filter)
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query I
 SELECT COUNT(*) FROM s1.bench_main WHERE category = 33 AND MOD(id, 11) = 0
@@ -237,7 +235,7 @@ SELECT COUNT(*) FROM s1.bench_main WHERE category = 33 AND MOD(id, 11) = 0
 46
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query I
 SELECT COUNT(*) FROM s1.bench_main WHERE category = 33 AND MOD(id, 11) = 0
@@ -246,7 +244,7 @@ SELECT COUNT(*) FROM s1.bench_main WHERE category = 33 AND MOD(id, 11) = 0
 
 # 3d: String filter
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query I
 SELECT COUNT(*) FROM s1.bench_main WHERE status = 'pending' AND category < 5
@@ -254,7 +252,7 @@ SELECT COUNT(*) FROM s1.bench_main WHERE status = 'pending' AND category < 5
 834
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query I
 SELECT COUNT(*) FROM s1.bench_main WHERE status = 'pending' AND category < 5
@@ -263,7 +261,7 @@ SELECT COUNT(*) FROM s1.bench_main WHERE status = 'pending' AND category < 5
 
 # Re-enable for remaining tests
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 # SECTION 4: Plan Cache — Hits, Invalidation, Generation Tracking
 
@@ -895,3 +893,15 @@ DROP TABLE IF EXISTS s1.bench_agg;
 
 statement ok
 DROP TABLE IF EXISTS s1.bench_main;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+RESET GLOBAL mysql_hint_injection_enabled
+
+statement ok
+RESET GLOBAL mysql_adaptive_replan_enabled
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_cost_model.test
+++ b/test/sql/predicate_analyzer/federation_cost_model.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_cost_model.test
+# name: test/sql/predicate_analyzer/federation_cost_model.test
 # description: Test cost model behavior for federation optimizer pushdown decisions
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create tables of varying sizes for cost estimation
 
@@ -144,3 +146,9 @@ DROP TABLE IF EXISTS s1.cost_small;
 
 statement ok
 DROP TABLE IF EXISTS s1.cost_large;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_cost_model_calibration.test
+++ b/test/sql/predicate_analyzer/federation_cost_model_calibration.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_cost_model_calibration.test
+# name: test/sql/predicate_analyzer/federation_cost_model_calibration.test
 # description: Validate cost model parameter calibration from multi-agent optimization analysis
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create tables for cost model validation
 
@@ -159,3 +161,9 @@ SELECT COUNT(DISTINCT indexed_val) FROM s1.cost_calibration
 
 statement ok
 DROP TABLE IF EXISTS s1.cost_calibration;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_efficiency_gains.test
+++ b/test/sql/predicate_analyzer/federation_efficiency_gains.test
@@ -1,24 +1,23 @@
-# name: test/sql/federation_efficiency_gains.test
+# name: test/sql/predicate_analyzer/federation_efficiency_gains.test
 # description: Demonstrate the efficiency gains of federated query optimization
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
+require-env MYSQL_TEST_PREDICATE_ANALYZER
+
 # SETUP — 50K rows with indexed and non-indexed columns, wide rows (~200 bytes)
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
-
-statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS loader (TYPE MYSQL_SCANNER)
-
-statement ok
-DETACH loader
-
-statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
+
+statement ok
+SET GLOBAL mysql_hint_injection_enabled = TRUE
 
 statement ok
 DROP TABLE IF EXISTS s1.eff_test;
@@ -420,7 +419,7 @@ SELECT id, val FROM s1.eff_order WHERE val < 10 ORDER BY id DESC LIMIT 3
 
 # 9a: Point lookup
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query II
 SELECT id, indexed_col FROM s1.eff_test WHERE id = 12345
@@ -428,7 +427,7 @@ SELECT id, indexed_col FROM s1.eff_test WHERE id = 12345
 12345	45
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query II
 SELECT id, indexed_col FROM s1.eff_test WHERE id = 12345
@@ -437,7 +436,7 @@ SELECT id, indexed_col FROM s1.eff_test WHERE id = 12345
 
 # 9b: Filtered aggregate
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query I
 SELECT SUM(id) FROM s1.eff_test WHERE indexed_col = 77
@@ -445,7 +444,7 @@ SELECT SUM(id) FROM s1.eff_test WHERE indexed_col = 77
 12513500
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query I
 SELECT SUM(id) FROM s1.eff_test WHERE indexed_col = 77
@@ -454,7 +453,7 @@ SELECT SUM(id) FROM s1.eff_test WHERE indexed_col = 77
 
 # 9c: Complex filter
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 query I
 SELECT COUNT(*) FROM s1.eff_test WHERE indexed_col < 5 AND status = 'active'
@@ -462,7 +461,7 @@ SELECT COUNT(*) FROM s1.eff_test WHERE indexed_col < 5 AND status = 'active'
 833
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 query I
 SELECT COUNT(*) FROM s1.eff_test WHERE indexed_col < 5 AND status = 'active'
@@ -471,7 +470,7 @@ SELECT COUNT(*) FROM s1.eff_test WHERE indexed_col < 5 AND status = 'active'
 
 # Re-enable for remaining tests
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 # GAIN 10: Cost Model Accuracy — The optimizer makes the RIGHT choice
 
@@ -520,3 +519,12 @@ DROP TABLE IF EXISTS s1.eff_partitioned;
 
 statement ok
 DROP TABLE IF EXISTS s1.eff_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_execution_plan.test
+++ b/test/sql/predicate_analyzer/federation_execution_plan.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_execution_plan.test
+# name: test/sql/predicate_analyzer/federation_execution_plan.test
 # description: Test execution plan selection based on cost model
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create tables to exercise different execution strategies
 
@@ -116,3 +118,9 @@ SELECT COUNT(*) FROM s1.plan_test WHERE indexed_col = 10 AND id > 25000 AND id <
 
 statement ok
 DROP TABLE IF EXISTS s1.plan_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_execution_strategies.test
+++ b/test/sql/predicate_analyzer/federation_execution_strategies.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_execution_strategies.test
+# name: test/sql/predicate_analyzer/federation_execution_strategies.test
 # description: Test that all execution strategies (PUSH_ALL, HYBRID) produce correct results
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create tables with different characteristics
 
@@ -248,3 +250,9 @@ SELECT SUM(id + indexed_val) FROM s1.exec_strategy_test WHERE indexed_val = 99
 
 statement ok
 DROP TABLE IF EXISTS s1.exec_strategy_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_hybrid_execution.test
+++ b/test/sql/predicate_analyzer/federation_hybrid_execution.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_hybrid_execution.test
+# name: test/sql/predicate_analyzer/federation_hybrid_execution.test
 # description: Test true hybrid filter execution - filter splitting between MySQL and DuckDB
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port=3306 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 statement ok
 DROP TABLE IF EXISTS s1.hybrid_test
@@ -112,3 +114,9 @@ WHERE id > 0
 # Cleanup
 statement ok
 DROP TABLE s1.hybrid_test
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_local_execution.test
+++ b/test/sql/predicate_analyzer/federation_local_execution.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_local_execution.test
+# name: test/sql/predicate_analyzer/federation_local_execution.test
 # description: Verify local filter execution for HYBRID and EXECUTE_ALL_LOCALLY strategies
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup
 
@@ -134,3 +136,9 @@ ORDER BY id LIMIT 3
 
 statement ok
 DROP TABLE IF EXISTS s1.local_exec_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_optimizer.test
+++ b/test/sql/predicate_analyzer/federation_optimizer.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_optimizer.test
+# name: test/sql/predicate_analyzer/federation_optimizer.test
 # description: Test federation optimizer components (statistics, predicate analyzer, cost model)
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create tables with indexes for optimizer testing
 
@@ -177,3 +179,9 @@ SELECT COUNT(*) FROM s1.optimizer_test WHERE indexed_col < 100
 
 statement ok
 DROP TABLE IF EXISTS s1.optimizer_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_statistics.test
+++ b/test/sql/predicate_analyzer/federation_statistics.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_statistics.test
+# name: test/sql/predicate_analyzer/federation_statistics.test
 # description: Test statistics collection and predicate analysis for federation optimizer
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create table with composite indexes
 
@@ -158,3 +160,9 @@ SELECT COUNT(*) FROM s1.stats_test WHERE id BETWEEN 0 AND 99
 
 statement ok
 DROP TABLE IF EXISTS s1.stats_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_strategy_verification.test
+++ b/test/sql/predicate_analyzer/federation_strategy_verification.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_strategy_verification.test
+# name: test/sql/predicate_analyzer/federation_strategy_verification.test
 # description: Verify federation optimizer strategy selection and plan cache behavior
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup
 
@@ -135,7 +137,7 @@ SELECT COUNT(*) FROM mysql_debug_execution_plan() WHERE table_name='strategy_tes
 
 # Test 8: Pushdown disabled - no plan cache entries
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=false;
+SET GLOBAL mysql_enable_predicate_analyzer=false;
 
 statement ok
 CALL mysql_clear_cache();
@@ -151,7 +153,7 @@ SELECT COUNT(*) FROM mysql_debug_execution_plan() WHERE table_name='strategy_tes
 0
 
 statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+SET GLOBAL mysql_enable_predicate_analyzer=true;
 
 # Test 9: No filters - no plan cache entry
 statement ok
@@ -216,3 +218,9 @@ SELECT COUNT(*) FROM s1.strategy_test WHERE non_indexed_val > 100
 
 statement ok
 DROP TABLE IF EXISTS s1.strategy_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/federation_types.test
+++ b/test/sql/predicate_analyzer/federation_types.test
@@ -1,16 +1,18 @@
-# name: test/sql/federation_types.test
+# name: test/sql/predicate_analyzer/federation_types.test
 # description: Test filter pushdown with various MySQL data types
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Integer Type Filter Pushdown
 
@@ -173,3 +175,9 @@ query I
 SELECT COUNT(*) FROM s1.datetime_tbl WHERE y >= 2000
 ----
 2
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/histogram_utilization.test
+++ b/test/sql/predicate_analyzer/histogram_utilization.test
@@ -1,6 +1,6 @@
-# name: test/sql/histogram_utilization.test
+# name: test/sql/predicate_analyzer/histogram_utilization.test
 # description: Test MySQL 8.0+ histogram statistics utilization for selectivity estimation
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
@@ -8,11 +8,13 @@ require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 require-env ORACLE_MYSQL_SERVER
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create table with skewed data distribution
 
@@ -129,6 +131,9 @@ CALL mysql_execute('s1', 'ANALYZE TABLE histogram_test DROP HISTOGRAM ON skewed_
 
 statement ok
 DROP TABLE IF EXISTS s1.histogram_test
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
 
 statement ok
 DETACH s1

--- a/test/sql/predicate_analyzer/optimization_benchmark.test
+++ b/test/sql/predicate_analyzer/optimization_benchmark.test
@@ -1,6 +1,6 @@
-# name: test/sql/optimization_benchmark.test
+# name: test/sql/predicate_analyzer/optimization_benchmark.test
 # description: Benchmark to measure value of optimizations
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
@@ -8,11 +8,16 @@ require-env MYSQL_TEST_DATABASE_AVAILABLE
 
 require-env ORACLE_MYSQL_SERVER
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
+
+statement ok
+SET GLOBAL mysql_hint_injection_enabled = TRUE
 
 # SETUP: Create benchmark tables
 
@@ -321,6 +326,12 @@ CALL mysql_execute('s1', 'ANALYZE TABLE optim_bench DROP HISTOGRAM ON col_a, col
 
 statement ok
 DROP TABLE IF EXISTS s1.optim_bench
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+RESET GLOBAL mysql_hint_injection_enabled
 
 statement ok
 DETACH s1

--- a/test/sql/predicate_analyzer/optimizer_hints.test
+++ b/test/sql/predicate_analyzer/optimizer_hints.test
@@ -1,22 +1,21 @@
-# name: test/sql/optimizer_hints.test
+# name: test/sql/predicate_analyzer/optimizer_hints.test
 # description: Test MySQL optimizer hint injection for stale statistics
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
-
-statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS loader (TYPE MYSQL_SCANNER)
-
-statement ok
-DETACH loader
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
+
+statement ok
+SET GLOBAL mysql_hint_injection_enabled = TRUE
 
 # Test Setup: Create table with indexes
 
@@ -125,3 +124,12 @@ DROP TABLE IF EXISTS s1.hint_test;
 
 statement ok
 DROP TABLE IF EXISTS s1.special_idx_test;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+RESET GLOBAL mysql_hint_injection_enabled
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/partition_pruning.test
+++ b/test/sql/predicate_analyzer/partition_pruning.test
@@ -1,16 +1,18 @@
-# name: test/sql/partition_pruning.test
+# name: test/sql/predicate_analyzer/partition_pruning.test
 # description: Test partition pruning optimization for MySQL partitioned tables
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true;
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
-ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create partitioned tables
 
@@ -154,3 +156,9 @@ DROP TABLE IF EXISTS s1.partitioned_regions;
 
 statement ok
 DROP TABLE IF EXISTS s1.partitioned_users;
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
+
+statement ok
+DETACH s1

--- a/test/sql/predicate_analyzer/predicate_reordering.test
+++ b/test/sql/predicate_analyzer/predicate_reordering.test
@@ -1,16 +1,18 @@
-# name: test/sql/predicate_reordering.test
+# name: test/sql/predicate_analyzer/predicate_reordering.test
 # description: Test predicate reordering to match composite index column order
-# group: [sql]
+# group: [predicate_analyzer]
 
 require mysql_scanner
 
 require-env MYSQL_TEST_DATABASE_AVAILABLE
 
-statement ok
-SET GLOBAL mysql_experimental_filter_pushdown=true
+require-env MYSQL_TEST_PREDICATE_ANALYZER
 
 statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+statement ok
+SET GLOBAL mysql_enable_predicate_analyzer = TRUE
 
 # Test Setup: Create table with composite index
 
@@ -197,6 +199,9 @@ DROP TABLE IF EXISTS s1.predicate_order_test
 
 statement ok
 DROP TABLE IF EXISTS s1.predicate_order_test2
+
+statement ok
+RESET GLOBAL mysql_enable_predicate_analyzer
 
 statement ok
 DETACH s1


### PR DESCRIPTION
This PR splits the filter pushdown configuration into two options:

 - `mysql_experimental_filter_pushdown` (default: `TRUE`): whether to allow "simple" filter pushdowns without using cost-based predicate analyzer
 - `mysql_enable_predicate_analyzer` (default: `FALSE`): whether to enable cost-based predicate analyzer (also enabled the former option)

Otherwize there are no functional changes.

Testing: test suite cleaned up without new tests.