### PR TITLE
Reintroduce results streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ SELECT * FROM mysql_db.tmp;
 | mysql_sql_buffer_result            | Add SQL_BUFFER_RESULT for large result sets to release row locks faster | true |
 | mysql_aggregate_pushdown_enabled   | Push aggregate functions (COUNT, SUM, etc.) to MySQL           | true   |
 | mysql_order_pushdown_enabled       | Push ORDER BY and LIMIT clauses to MySQL                       | true   |
+| mysql_allow_results_streaming      | Whether to allow streaming results of MySQL scans when only a single scan used in a query | true   |
 
 ## Schema Cache
 

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -249,6 +249,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("mysql_order_pushdown_enabled",
 	                          "Push ORDER BY and LIMIT clauses to MySQL (default: true)", LogicalType::BOOLEAN,
 	                          Value::BOOLEAN(true));
+	config.AddExtensionOption(
+	    "mysql_allow_results_streaming",
+	    "Whether to allow streaming results of MySQL scans when only a single scan used in a query (default: true)",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
 	OptimizerExtension mysql_optimizer;
 	mysql_optimizer.optimize_function = MySQLOptimizer::Optimize;
 	OptimizerExtension::Register(config, std::move(mysql_optimizer));

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -408,7 +408,7 @@ static unique_ptr<GlobalTableFunctionState> MySQLInitGlobalState(ClientContext &
 			agg_fed.execution_plan.estimated_cost.cpu_cost = static_cast<double>(MIN_QUERY_TIMEOUT_MS);
 			InjectQueryHints(context, select, agg_fed, bind_data, con, mysql_catalog.GetStatsCache());
 		}
-		auto query_result = con.Query(select, MySQLResultStreaming::FORCE_MATERIALIZATION);
+		auto query_result = con.Query(select, bind_data.streaming);
 		return make_uniq<MySQLGlobalState>(std::move(query_result));
 	}
 
@@ -506,7 +506,7 @@ static unique_ptr<GlobalTableFunctionState> MySQLInitGlobalState(ClientContext &
 		InjectQueryHints(context, select, fed, bind_data, con, mysql_catalog.GetStatsCache());
 	}
 
-	auto query_result = con.Query(select, MySQLResultStreaming::FORCE_MATERIALIZATION);
+	auto query_result = con.Query(select, bind_data.streaming);
 	auto result = make_uniq<MySQLGlobalState>(std::move(query_result));
 
 	if (bind_data.use_predicate_analyzer) {

--- a/src/storage/mysql_optimizer.cpp
+++ b/src/storage/mysql_optimizer.cpp
@@ -765,11 +765,25 @@ void OptimizeOrderByAndLimit(ClientContext &context, unique_ptr<LogicalOperator>
 }
 
 void MySQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	vector<AggregateRewriteInfo> rewrites;
+	OptimizeAggregates(input.context, plan, rewrites);
+	for (auto &info : rewrites) {
+		RewriteBindingsInTree(*plan, info);
+	}
+
+	OptimizeOrderByAndLimit(input.context, plan);
+
+	Value allow_streaming_val;
+	bool allow_streaming = false;
+	if (input.context.TryGetCurrentSetting("mysql_allow_results_streaming", allow_streaming_val)) {
+		allow_streaming = BooleanValue::Get(allow_streaming_val);
+	}
+
 	MySQLOperators operators;
 	GatherMySQLScans(*plan, operators);
 	for (auto &entry : operators.scans) {
 		MySQLResultStreaming result_streaming = MySQLResultStreaming::FORCE_MATERIALIZATION;
-		if (entry.second.size() == 1) {
+		if (entry.second.size() == 1 && allow_streaming) {
 			result_streaming = MySQLResultStreaming::ALLOW_STREAMING;
 		}
 		for (auto &logical_get : entry.second) {
@@ -783,14 +797,6 @@ void MySQLOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<Logical
 			}
 		}
 	}
-
-	vector<AggregateRewriteInfo> rewrites;
-	OptimizeAggregates(input.context, plan, rewrites);
-	for (auto &info : rewrites) {
-		RewriteBindingsInTree(*plan, info);
-	}
-
-	OptimizeOrderByAndLimit(input.context, plan);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This PR adds back the support for reading MySQL scan results without buffering the whole result in memory. Streaming is only possible when the query contains exatcly 1 MySQL scan. This support was previously disabled in #217.

New option is added:

 - `mysql_allow_results_streaming` (BOOL, default: `TRUE`)

Testing: streaming logic is covered by existing
`multi_scan_streaming_safety` and `multi_scan_aggregate` tests.